### PR TITLE
WebSocket proxying

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,18 @@ This will *ask* Google et al not to index and list your site. Be careful with th
 * You can check the status of a specific jail via `docker exec -it swag fail2ban-client status <jail name>`
 * You can unban an IP via `docker exec -it swag fail2ban-client set <jail name> unbanip <IP>`
 * A list of commands can be found here: https://www.fail2ban.org/wiki/index.php/Commands
+### Updating configs
+* This container creates a number of configs for nginx, proxy samples, etc.
+* Config updates are noted in the changelog but not automatically applied to your files.
+* If you have modified a file with noted changes in the changelog:
+  1. Keep your existing configs as is (not broken, don't fix)
+  2. Review our repository commits and apply the new changes yourself
+  3. Delete the modified config file with listed updates, restart the container, reapply your changes
+* If you have NOT modified a file with noted changes in the changelog:
+  1. Delete the config file with listed updates, restart the container, reapply your changes
+* Proxy sample updates are not listed in the changelog. See the changes here: [https://github.com/linuxserver/reverse-proxy-confs/commits/master](https://github.com/linuxserver/reverse-proxy-confs/commits/master)
+* Proxy sample files WILL be updated, however your renamed (enabled) proxy files will not.
+* You can check the new sample and adjust your active config as needed.
 
 
 ## Docker Mods
@@ -303,4 +315,5 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **01.09.20:** - Update nginx.conf and proxy.conf (and various proxy samples) to better handle websockets.
 * **03.08.20:** - Initial release.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -84,7 +84,7 @@ app_setup_block: |
   >   * Edit the compose yaml to change the image to `linuxserver/swag` and change the service and container names to `swag`
   >   * Issue `docker-compose up -d --remove-orphans`
   >   * If you don't want to or can't use the option `--remove-orphans`, then you can first do `docker-compose down`, then edit the compose yaml as above, and then issue `docker-compose up -d`
-  
+
   > Make sure to also update any references to this container by name. For instance, Nextcloud's `config.php` references this container in its `trusted_proxies` directive, which would have to be updated to `swag`.
   ### Validation and initial setup
   * Before running this container, make sure that the url and subdomains are properly forwarded to this container's host, and that port 443 (and/or 80) is not being used by another service on the host (NAS gui, another webserver, etc.).
@@ -130,10 +130,23 @@ app_setup_block: |
   * You can check the status of a specific jail via `docker exec -it swag fail2ban-client status <jail name>`
   * You can unban an IP via `docker exec -it swag fail2ban-client set <jail name> unbanip <IP>`
   * A list of commands can be found here: https://www.fail2ban.org/wiki/index.php/Commands
+  ### Updating configs
+  * This container creates a number of configs for nginx, proxy samples, etc.
+  * Config updates are noted in the changelog but not automatically applied to your files.
+  * If you have modified a file with noted changes in the changelog:
+    1. Keep your existing configs as is (not broken, don't fix)
+    2. Review our repository commits and apply the new changes yourself
+    3. Delete the modified config file with listed updates, restart the container, reapply your changes
+  * If you have NOT modified a file with noted changes in the changelog:
+    1. Delete the config file with listed updates, restart the container, reapply your changes
+  * Proxy sample updates are not listed in the changelog. See the changes here: [https://github.com/linuxserver/reverse-proxy-confs/commits/master](https://github.com/linuxserver/reverse-proxy-confs/commits/master)
+  * Proxy sample files WILL be updated, however your renamed (enabled) proxy files will not.
+  * You can check the new sample and adjust your active config as needed.
 
 app_setup_nginx_reverse_proxy_snippet: false
 app_setup_nginx_reverse_proxy_block: ""
 
 # changelog
 changelogs:
+  - { date: "01.09.20:", desc: "Update nginx.conf and proxy.conf (and various proxy samples) to better handle websockets." }
   - { date: "03.08.20:", desc: "Initial release." }

--- a/root/defaults/nginx.conf
+++ b/root/defaults/nginx.conf
@@ -75,10 +75,10 @@ http {
 	##
 	# WebSocket proxying
 	##
-    map $http_upgrade $connection_upgrade {
-        default upgrade;
-        ''      close;
-    }
+	map $http_upgrade $connection_upgrade {
+		default upgrade;
+		''      close;
+	}
 
 	##
 	# Virtual Host Configs

--- a/root/defaults/nginx.conf
+++ b/root/defaults/nginx.conf
@@ -1,4 +1,4 @@
-## Version 2019/12/19 - Changelog: https://github.com/linuxserver/docker-swag/commits/master/root/defaults/nginx.conf
+## Version 2020/09/01 - Changelog: https://github.com/linuxserver/docker-swag/commits/master/root/defaults/nginx.conf
 
 user abc;
 worker_processes 4;

--- a/root/defaults/nginx.conf
+++ b/root/defaults/nginx.conf
@@ -23,7 +23,7 @@ http {
 	types_hash_max_size 2048;
 	variables_hash_max_size 2048;
 	large_client_header_buffers 4 16k;
-	
+
 	# server_tokens off;
 
 	# server_names_hash_bucket_size 64;
@@ -71,6 +71,14 @@ http {
 
 	#passenger_root /usr;
 	#passenger_ruby /usr/bin/ruby;
+
+	##
+	# WebSocket proxying
+	##
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      close;
+    }
 
 	##
 	# Virtual Host Configs

--- a/root/defaults/proxy.conf
+++ b/root/defaults/proxy.conf
@@ -1,4 +1,4 @@
-## Version 2019/10/23 - Changelog: https://github.com/linuxserver/docker-swag/commits/master/root/defaults/proxy.conf
+## Version 2020/09/01 - Changelog: https://github.com/linuxserver/docker-swag/commits/master/root/defaults/proxy.conf
 
 client_body_buffer_size 128k;
 

--- a/root/defaults/proxy.conf
+++ b/root/defaults/proxy.conf
@@ -23,7 +23,8 @@ proxy_set_header X-Forwarded-Host $host;
 proxy_set_header X-Forwarded-Ssl on;
 proxy_redirect  http://  $scheme://;
 proxy_http_version 1.1;
-proxy_set_header Connection "";
+proxy_set_header Upgrade $http_upgrade;
+proxy_set_header Connection $connection_upgrade;
 #proxy_cookie_path / "/; HTTPOnly; Secure"; # enable at your own risk, may break certain apps
 proxy_cache_bypass $cookie_session;
 proxy_no_cache $cookie_session;


### PR DESCRIPTION
http://nginx.org/en/docs/http/websocket.html

Many of our https://github.com/linuxserver/reverse-proxy-confs already include similar headers but not done in the way recommended in the nginx docs. This covers them all with the ability to proxy websockets.

I will create a separate PR to cleanup/adjust proxy samples in that repo.

Edit: https://github.com/linuxserver/reverse-proxy-confs/pull/197 should be merged BEFORE this.