### PR TITLE
Cleanups and reordering

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -139,7 +139,7 @@ app_setup_block: |
     2. Review our repository commits and apply the new changes yourself
     3. Delete the modified config file with listed updates, restart the container, reapply your changes
   * If you have NOT modified a file with noted changes in the changelog:
-    1. Delete the config file with listed updates, restart the container, reapply your changes
+    1. Delete the config file with listed updates, restart the container
   * Proxy sample updates are not listed in the changelog. See the changes here: [https://github.com/linuxserver/reverse-proxy-confs/commits/master](https://github.com/linuxserver/reverse-proxy-confs/commits/master)
   * Proxy sample files WILL be updated, however your renamed (enabled) proxy files will not.
   * You can check the new sample and adjust your active config as needed.
@@ -149,7 +149,7 @@ app_setup_nginx_reverse_proxy_block: ""
 
 # changelog
 changelogs:
-  - { date: "20.09.20:", desc: "Update nginx.conf - Added geoip2 configs. Added MAXMINDDB_LICENSE_KEY variable to readme."}
+  - { date: "20.09.20:", desc: "[Existing users should update:](https://github.com/linuxserver/docker-swag/blob/master/README.md#updating-configs) nginx.conf - Added geoip2 configs. Added MAXMINDDB_LICENSE_KEY variable to readme."}
   - { date: "08.09.20:", desc: "Add php7-xsl." }
-  - { date: "01.09.20:", desc: "Update nginx.conf and proxy.conf (and various proxy samples) to better handle websockets." }
+  - { date: "01.09.20:", desc: "[Existing users should update:](https://github.com/linuxserver/docker-swag/blob/master/README.md#updating-configs) nginx.conf, proxy.conf, and various proxy samples - Global websockets across all configs." }
   - { date: "03.08.20:", desc: "Initial release." }

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -149,7 +149,7 @@ app_setup_nginx_reverse_proxy_block: ""
 
 # changelog
 changelogs:
-  - { date: "01.09.25:", desc: "[Existing users should update:](https://github.com/linuxserver/docker-swag/blob/master/README.md#updating-configs) nginx.conf, proxy.conf, and ssl.conf - Minor cleanups and reordering." }
+  - { date: "04.10.20:", desc: "[Existing users should update:](https://github.com/linuxserver/docker-swag/blob/master/README.md#updating-configs) nginx.conf, proxy.conf, and ssl.conf - Minor cleanups and reordering." }
   - { date: "20.09.20:", desc: "[Existing users should update:](https://github.com/linuxserver/docker-swag/blob/master/README.md#updating-configs) nginx.conf - Added geoip2 configs. Added MAXMINDDB_LICENSE_KEY variable to readme."}
   - { date: "08.09.20:", desc: "Add php7-xsl." }
   - { date: "01.09.20:", desc: "[Existing users should update:](https://github.com/linuxserver/docker-swag/blob/master/README.md#updating-configs) nginx.conf, proxy.conf, and various proxy samples - Global websockets across all configs." }

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -149,6 +149,7 @@ app_setup_nginx_reverse_proxy_block: ""
 
 # changelog
 changelogs:
+  - { date: "01.09.25:", desc: "[Existing users should update:](https://github.com/linuxserver/docker-swag/blob/master/README.md#updating-configs) nginx.conf, proxy.conf, and ssl.conf - Minor cleanups and reordering." }
   - { date: "20.09.20:", desc: "[Existing users should update:](https://github.com/linuxserver/docker-swag/blob/master/README.md#updating-configs) nginx.conf - Added geoip2 configs. Added MAXMINDDB_LICENSE_KEY variable to readme."}
   - { date: "08.09.20:", desc: "Add php7-xsl." }
   - { date: "01.09.20:", desc: "[Existing users should update:](https://github.com/linuxserver/docker-swag/blob/master/README.md#updating-configs) nginx.conf, proxy.conf, and various proxy samples - Global websockets across all configs." }

--- a/root/defaults/nginx.conf
+++ b/root/defaults/nginx.conf
@@ -1,4 +1,4 @@
-## Version 2020/09/25 - Changelog: https://github.com/linuxserver/docker-swag/commits/master/root/defaults/nginx.conf
+## Version 2020/10/04 - Changelog: https://github.com/linuxserver/docker-swag/commits/master/root/defaults/nginx.conf
 
 user abc;
 worker_processes 4;

--- a/root/defaults/nginx.conf
+++ b/root/defaults/nginx.conf
@@ -1,4 +1,4 @@
-## Version 2020/09/20 - Changelog: https://github.com/linuxserver/docker-swag/commits/master/root/defaults/nginx.conf
+## Version 2020/09/25 - Changelog: https://github.com/linuxserver/docker-swag/commits/master/root/defaults/nginx.conf
 
 user abc;
 worker_processes 4;
@@ -16,20 +16,20 @@ http {
 	# Basic Settings
 	##
 
-	sendfile on;
-	tcp_nopush on;
-	tcp_nodelay on;
+	client_body_buffer_size 128k;
+	client_max_body_size 0;
 	keepalive_timeout 65;
+	large_client_header_buffers 4 16k;
+	send_timeout 5m;
+	sendfile on;
+	tcp_nodelay on;
+	tcp_nopush on;
 	types_hash_max_size 2048;
 	variables_hash_max_size 2048;
-	large_client_header_buffers 4 16k;
 
 	# server_tokens off;
-
 	# server_names_hash_bucket_size 64;
 	# server_name_in_redirect off;
-
-	client_max_body_size 0;
 
 	include /etc/nginx/mime.types;
 	default_type application/octet-stream;
@@ -90,9 +90,9 @@ http {
 	##
 	# Geoip2 config
 	##
-	# Uncomment to add the Geoip2 configs needed to geo block countries/cities. 
+	# Uncomment to add the Geoip2 configs needed to geo block countries/cities.
 	##
-	
+
 	#include /config/nginx/geoip2.conf;
 }
 

--- a/root/defaults/proxy.conf
+++ b/root/defaults/proxy.conf
@@ -1,33 +1,30 @@
-## Version 2020/09/01 - Changelog: https://github.com/linuxserver/docker-swag/commits/master/root/defaults/proxy.conf
+## Version 2020/09/25 - Changelog: https://github.com/linuxserver/docker-swag/commits/master/root/defaults/proxy.conf
 
-client_body_buffer_size 128k;
-
-#Timeout if the real server is dead
+# Timeout if the real server is dead
 proxy_next_upstream error timeout invalid_header http_500 http_502 http_503;
 
-# Advanced Proxy Config
-send_timeout 5m;
-proxy_read_timeout 240;
-proxy_send_timeout 240;
-proxy_connect_timeout 240;
-
-# TLS 1.3 early data
-proxy_set_header Early-Data $ssl_early_data;
-
-# Basic Proxy Config
-proxy_set_header Host $host;
-proxy_set_header X-Real-IP $remote_addr;
-proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-proxy_set_header X-Forwarded-Proto https;
-proxy_set_header X-Forwarded-Host $host;
-proxy_set_header X-Forwarded-Ssl on;
-proxy_redirect  http://  $scheme://;
-proxy_http_version 1.1;
-proxy_set_header Upgrade $http_upgrade;
-proxy_set_header Connection $connection_upgrade;
-#proxy_cookie_path / "/; HTTPOnly; Secure"; # enable at your own risk, may break certain apps
-proxy_cache_bypass $cookie_session;
-proxy_no_cache $cookie_session;
+# Proxy Connection Settings
 proxy_buffers 32 4k;
+proxy_connect_timeout 240;
 proxy_headers_hash_bucket_size 128;
 proxy_headers_hash_max_size 1024;
+proxy_http_version 1.1;
+proxy_read_timeout 240;
+proxy_redirect  http://  $scheme://;
+proxy_send_timeout 240;
+
+# Proxy Cache and Cookie Settings
+proxy_cache_bypass $cookie_session;
+#proxy_cookie_path / "/; Secure"; # enable at your own risk, may break certain apps
+proxy_no_cache $cookie_session;
+
+# Proxy Header Settings
+proxy_set_header Connection $connection_upgrade;
+proxy_set_header Early-Data $ssl_early_data;
+proxy_set_header Host $host;
+proxy_set_header Upgrade $http_upgrade;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Host $host;
+proxy_set_header X-Forwarded-Proto https;
+proxy_set_header X-Forwarded-Ssl on;
+proxy_set_header X-Real-IP $remote_addr;

--- a/root/defaults/proxy.conf
+++ b/root/defaults/proxy.conf
@@ -1,4 +1,4 @@
-## Version 2020/09/25 - Changelog: https://github.com/linuxserver/docker-swag/commits/master/root/defaults/proxy.conf
+## Version 2020/10/04 - Changelog: https://github.com/linuxserver/docker-swag/commits/master/root/defaults/proxy.conf
 
 # Timeout if the real server is dead
 proxy_next_upstream error timeout invalid_header http_500 http_502 http_503;

--- a/root/defaults/ssl.conf
+++ b/root/defaults/ssl.conf
@@ -1,4 +1,4 @@
-## Version 2020/06/17 - Changelog: https://github.com/linuxserver/docker-swag/commits/master/root/defaults/ssl.conf
+## Version 2020/09/25 - Changelog: https://github.com/linuxserver/docker-swag/commits/master/root/defaults/ssl.conf
 
 ### Mozilla Recommendations
 # generated 2020-06-17, Mozilla Guideline v5.4, nginx 1.18.0-r0, OpenSSL 1.1.1g-r0, intermediate configuration
@@ -39,10 +39,10 @@ ssl_early_data on;
 #add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
 
 # Optional additional headers
-#add_header Content-Security-Policy "upgrade-insecure-requests";
-#add_header X-Frame-Options "SAMEORIGIN" always;
-#add_header X-XSS-Protection "1; mode=block" always;
-#add_header X-Content-Type-Options "nosniff" always;
-#add_header X-UA-Compatible "IE=Edge" always;
 #add_header Cache-Control "no-transform" always;
+#add_header Content-Security-Policy "upgrade-insecure-requests";
 #add_header Referrer-Policy "same-origin" always;
+#add_header X-Content-Type-Options "nosniff" always;
+#add_header X-Frame-Options "SAMEORIGIN" always;
+#add_header X-UA-Compatible "IE=Edge" always;
+#add_header X-XSS-Protection "1; mode=block" always;

--- a/root/defaults/ssl.conf
+++ b/root/defaults/ssl.conf
@@ -1,4 +1,4 @@
-## Version 2020/09/25 - Changelog: https://github.com/linuxserver/docker-swag/commits/master/root/defaults/ssl.conf
+## Version 2020/10/04 - Changelog: https://github.com/linuxserver/docker-swag/commits/master/root/defaults/ssl.conf
 
 ### Mozilla Recommendations
 # generated 2020-06-17, Mozilla Guideline v5.4, nginx 1.18.0-r0, OpenSSL 1.1.1g-r0, intermediate configuration


### PR DESCRIPTION
Biggest change here is moving `client_body_buffer_size 128k;	# Timeout if the real server is dead` and `send_timeout 5m;` from proxy.conf to nginx.conf. Keeps only proxy related settings in proxy.conf. The rest is just sorting alphabetically for ease of finding what you're looking for.