### PR TITLE
Add server_port to X-Forwarded-Host

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **11.10.20:** - [Existing users should update:](https://github.com/linuxserver/docker-swag/blob/master/README.md#updating-configs) proxy.conf - Add server_port to X-Forwarded-Host.
 * **04.10.20:** - [Existing users should update:](https://github.com/linuxserver/docker-swag/blob/master/README.md#updating-configs) nginx.conf, proxy.conf, and ssl.conf - Minor cleanups and reordering.
 * **20.09.20:** - [Existing users should update:](https://github.com/linuxserver/docker-swag/blob/master/README.md#updating-configs) nginx.conf - Added geoip2 configs. Added MAXMINDDB_LICENSE_KEY variable to readme.
 * **08.09.20:** - Add php7-xsl.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -149,6 +149,7 @@ app_setup_nginx_reverse_proxy_block: ""
 
 # changelog
 changelogs:
+  - { date: "11.10.20:", desc: "[Existing users should update:](https://github.com/linuxserver/docker-swag/blob/master/README.md#updating-configs) proxy.conf - Add server_port to X-Forwarded-Host." }
   - { date: "04.10.20:", desc: "[Existing users should update:](https://github.com/linuxserver/docker-swag/blob/master/README.md#updating-configs) nginx.conf, proxy.conf, and ssl.conf - Minor cleanups and reordering." }
   - { date: "20.09.20:", desc: "[Existing users should update:](https://github.com/linuxserver/docker-swag/blob/master/README.md#updating-configs) nginx.conf - Added geoip2 configs. Added MAXMINDDB_LICENSE_KEY variable to readme."}
   - { date: "08.09.20:", desc: "Add php7-xsl." }

--- a/root/defaults/proxy.conf
+++ b/root/defaults/proxy.conf
@@ -24,7 +24,7 @@ proxy_set_header Early-Data $ssl_early_data;
 proxy_set_header Host $host;
 proxy_set_header Upgrade $http_upgrade;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-proxy_set_header X-Forwarded-Host $host;
+proxy_set_header X-Forwarded-Host $host:$server_port;
 proxy_set_header X-Forwarded-Proto https;
 proxy_set_header X-Forwarded-Ssl on;
 proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
Only official docs I can find mentioning any use of `X-Forwarded-Host` at all are https://www.nginx.com/resources/wiki/start/topics/examples/likeapache/ which use

```nginx
proxy_set_header X-Forwarded-Host $host:$server_port;

```

This possibly solves https://github.com/linuxserver/reverse-proxy-confs/issues/223 (opening this PR as draft until we hear a confirmation if this resolves the issue).