### PR TITLE
Set frame-ancestors in Content-Security-Policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **29.10.20:** - [Existing users should update:](https://github.com/linuxserver/docker-swag/blob/master/README.md#updating-configs) ssl.conf - Add frame-ancestors to Content-Security-Policy.
 * **04.10.20:** - [Existing users should update:](https://github.com/linuxserver/docker-swag/blob/master/README.md#updating-configs) nginx.conf, proxy.conf, and ssl.conf - Minor cleanups and reordering.
 * **20.09.20:** - [Existing users should update:](https://github.com/linuxserver/docker-swag/blob/master/README.md#updating-configs) nginx.conf - Added geoip2 configs. Added MAXMINDDB_LICENSE_KEY variable to readme.
 * **08.09.20:** - Add php7-xsl.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -149,6 +149,7 @@ app_setup_nginx_reverse_proxy_block: ""
 
 # changelog
 changelogs:
+  - { date: "29.10.20:", desc: "[Existing users should update:](https://github.com/linuxserver/docker-swag/blob/master/README.md#updating-configs) ssl.conf - Add frame-ancestors to Content-Security-Policy." }
   - { date: "04.10.20:", desc: "[Existing users should update:](https://github.com/linuxserver/docker-swag/blob/master/README.md#updating-configs) nginx.conf, proxy.conf, and ssl.conf - Minor cleanups and reordering." }
   - { date: "20.09.20:", desc: "[Existing users should update:](https://github.com/linuxserver/docker-swag/blob/master/README.md#updating-configs) nginx.conf - Added geoip2 configs. Added MAXMINDDB_LICENSE_KEY variable to readme."}
   - { date: "08.09.20:", desc: "Add php7-xsl." }

--- a/root/defaults/ssl.conf
+++ b/root/defaults/ssl.conf
@@ -1,4 +1,4 @@
-## Version 2020/10/04 - Changelog: https://github.com/linuxserver/docker-swag/commits/master/root/defaults/ssl.conf
+## Version 2020/10/29 - Changelog: https://github.com/linuxserver/docker-swag/commits/master/root/defaults/ssl.conf
 
 ### Mozilla Recommendations
 # generated 2020-06-17, Mozilla Guideline v5.4, nginx 1.18.0-r0, OpenSSL 1.1.1g-r0, intermediate configuration

--- a/root/defaults/ssl.conf
+++ b/root/defaults/ssl.conf
@@ -40,7 +40,7 @@ ssl_early_data on;
 
 # Optional additional headers
 #add_header Cache-Control "no-transform" always;
-#add_header Content-Security-Policy "upgrade-insecure-requests";
+#add_header Content-Security-Policy "upgrade-insecure-requests; frame-ancestors 'self'";
 #add_header Referrer-Policy "same-origin" always;
 #add_header X-Content-Type-Options "nosniff" always;
 #add_header X-Frame-Options "SAMEORIGIN" always;


### PR DESCRIPTION
https://infosec.mozilla.org/guidelines/web_security#x-frame-options

> `X-Frame-Options` has been superseded by the Content Security Policy’s `frame-ancestors` directive, which allows considerably more granular control over the origins allowed to frame a site. As `frame-ancestors` is not yet supported in IE11 and older, Edge, Safari 9.1 (desktop), and Safari 9.2 (iOS), it is recommended that sites employ `X-Frame-Options` in addition to using CSP.

This change is included in an optional header, so not enabled by default.