### PR TITLE
passing znc irc port (not http) through the swag reverse proxy

### DIFF
--- a/root/defaults/nginx.conf
+++ b/root/defaults/nginx.conf
@@ -118,16 +118,19 @@ http {
 #	}
 #}
 
+
+#	# Enable this to forward a non http/ssl port
+#	# In this example the znc irc port
 #stream {
 #
 #  upstream znc {
-#      server znc:6502;
+#      server znc:6501;
 #  }
 #
 #  server {
 #
-#      listen      6502 ssl;
-#      listen      [::]:6502 ssl;
+#      listen      6501 ssl;
+#      listen      [::]:6501 ssl;
 #
 #      # Certificates
 #      ssl_certificate /config/keys/letsencrypt/fullchain.pem;

--- a/root/defaults/nginx.conf
+++ b/root/defaults/nginx.conf
@@ -117,4 +117,27 @@ http {
 #		proxy      on;
 #	}
 #}
+
+#stream {
+#
+#  upstream znc {
+#      server znc:6502;
+#  }
+#
+#  server {
+#
+#      listen      6502 ssl;
+#      listen      [::]:6502 ssl;
+#
+#      # Certificates
+#      ssl_certificate /config/keys/letsencrypt/fullchain.pem;
+#      ssl_certificate_key /config/keys/letsencrypt/privkey.pem;
+#      # verify chain of trust of OCSP response using Root CA and Intermediate certs
+#      ssl_trusted_certificate /config/keys/letsencrypt/fullchain.pem;
+#      # Diffie-Hellman Parameters
+#      ssl_dhparam /config/nginx/dhparams.pem;
+#
+#      proxy_pass znc;
+#  }
+#}
 daemon off;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-swag/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->

I've successfully port forwarded the IRC port for znc and added instructions to the znc.subdomain.conf.sample (https://github.com/linuxserver/reverse-proxy-confs/pull/267)

To be very clear this addition is not for http but to proxy the irc port through swag.
Nginx will accept port 6501 on any subdomain and pass it through to znc

Added stream section to nginx.conf
Added # to disable it by default

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
My reasoning for doing it is to avoid configuring ssl certificates in znc.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It has bin tested with the latest version of swag and the znc.subdomain.conf

changing nginx.conf and znc.subdomain.conf and stopping and removing the container and then deploying it with docker-compose.

It does not seem to work with a subfolder but i imagine this is the fault of the irc clients.

using multiple irc clients inside and outside my network.
Port 6501 was port fowarded from my router to my swag port.

You will also need to expose port 6501 on the SWAG container for this to work.

I did not build swag to test it.

I'm not a professional so this is not SWAG quality but do with this as you please.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
https://wiki.znc.in/Reverse_Proxy
https://nginx.org/en/docs/stream/ngx_stream_core_module.html
https://www.reddit.com/r/irc/comments/k1m54u/help_reverse_proxying_znc/