### PR TITLE
Added le-force-renew.sh convenience script that forces renewal of certificates

### DIFF
--- a/root/app/le-force-renew.sh
+++ b/root/app/le-force-renew.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/with-contenv bash
+
+. /config/.donoteditthisfile.conf
+
+echo "<------------------------------------------------->"
+echo "<----------FORCED RENEWAL OF CERTIFICATES--------->"
+echo "<------------------------------------------------->"
+echo "Running certbot forced renew"
+if [ "$ORIGVALIDATION" = "dns" ] || [ "$ORIGVALIDATION" = "duckdns" ]; then
+  certbot -n --force-renewal renew \
+    --post-hook "if ps aux | grep [n]ginx: > /dev/null; then s6-svc -h /var/run/s6/services/nginx; fi; \
+    cd /config/keys/letsencrypt && \
+    openssl pkcs12 -export -out privkey.pfx -inkey privkey.pem -in cert.pem -certfile chain.pem -passout pass: && \
+    sleep 1 && \
+    cat privkey.pem fullchain.pem > priv-fullchain-bundle.pem && \
+    chown -R abc:abc /config/etc/letsencrypt"
+else
+  certbot -n --force-renewal renew \
+    --pre-hook "if ps aux | grep [n]ginx: > /dev/null; then s6-svc -d /var/run/s6/services/nginx; fi" \
+    --post-hook "if ps aux | grep 's6-supervise nginx' | grep -v grep > /dev/null; then s6-svc -u /var/run/s6/services/nginx; fi; \
+    cd /config/keys/letsencrypt && \
+    openssl pkcs12 -export -out privkey.pfx -inkey privkey.pem -in cert.pem -certfile chain.pem -passout pass: && \
+    sleep 1 && \
+    cat privkey.pem fullchain.pem > priv-fullchain-bundle.pem && \
+    chown -R abc:abc /config/etc/letsencrypt"
+fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-swag/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Added le-force-renew.sh that forces renewal of certificates. This script is meant to be run from inside the container to force renewal of certificates

## Benefits of this PR and context:
It's not difficult to test that you have setup other containers to mount swag generated certificates
correctly. However that changes, when certificates get renewed. Depending on your application/server software,
it may have to be restarted or otherwise specifically configured to dynamically load the new certificates on runtime.
Even staging certificates have a 3 month expiration date, so the only 'easy' way (currently) to test what really
happens when mounting the certificates on other containers, is to force a renewal of those certificates by clearing the
./config volume.
This PR adds a convenience script (le-force-renew.sh), essentially a copy of le-renew.sh
The differences are that it runs `certbot renew` with the `--force-renewal` flag, and it doesn't run automatically on
a cron job, but has to be launched manually from inside the docker container. Combined with the use of staging
certificates (to avoid hitting rate limits) it should be useful to debug issues with mounting certificates in other
containers.

## How Has This Been Tested?
Building the image has not been tested. Only added and tested the script on an already running container.


## Source / References:
N/A
