### PR TITLE
Add documentation TransIP DNS TXT usage

### DIFF
--- a/root/defaults/dns-conf/transip.ini
+++ b/root/defaults/dns-conf/transip.ini
@@ -1,6 +1,30 @@
 # Instructions: https://readthedocs.org/projects/certbot-dns-transip/
-# Convert the key to an RSA key (openssl rsa -in transip.key -out transip-rsa.key)
-# Place .key-file in the same directory as this file. Location "/config/dns-conf" is from within the container
+#
+# This DNS plugin can be used to generate SSL wildcard certificates via TransIP DNS TXT records
+#
+# Login with your TransIP account and go to My Account | API:
+# 1. API-settings: On
+#
+# 2. IP-address/ranges whitelist: Add a new authorized IP address (Swag Docker) to use the API
+#
+# 3. Generate a new Key Pair and copy the private key to a new transip.key file in the format:
+#    -----BEGIN PRIVATE KEY-----
+#    ...
+#    -----END PRIVATE KEY-----
+#
+# 4. Convert the key to an RSA key with command:
+#     openssl rsa -in transip.key -out /config/dns-conf/transip-rsa.key
+#
+# 5. Set permission
+#     chmod 600 /config/dns-conf/transip-rsa.key
+#
+# 6. Replace <transip_username> below with your TransIP username
+#
+# 7. Create wildcard certificate with Swag environment variables:
+#      SUBDOMAINS=wildcard
+#      VALIDATION=dns
+#      DNSPLUGIN=transip
 
 dns_transip_username = <transip_username>
 dns_transip_key_file = /config/dns-conf/transip-rsa.key
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-swag/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->

Add documentation TransIP DNS plugin file `/swag/config/dns-conf/transip.ini`.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

The original text in the `transip.ini` file was unclear. I was not able to generate a wildcard certificate by insufficient instructions in the comments and documentation URL. Finally I discovered that the `transip.key` is a TransIP API key pair. Then it was very easy to use this plugin.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

No source changes made, only comments added. Log:

```
swag             | Using Let's Encrypt as the cert provider
swag             | SUBDOMAINS entered, processing
swag             | Wildcard cert for mydomain.nl will be requested
swag             | E-mail address entered: removed@mydomain.nl
swag             | dns validation via transip plugin is selected
swag             | Generating new certificate
swag             | Saving debug log to /var/log/letsencrypt/letsencrypt.log
swag             | Plugins selected: Authenticator dns-transip, Installer None
swag             | Requesting a certificate for *.mydomain.nl and mydomain.nl
swag             | Performing the following challenges:
swag             | dns-01 challenge for mydomain.nl
swag             | dns-01 challenge for mydomain.nl
swag             | Unsafe permissions on credentials configuration file: /config/dns-conf/transip.ini
swag             | Successfully added TXT record
swag             | Successfully added TXT record
swag             | Waiting 240 seconds for DNS changes to propagate
swag             | Waiting for verification...
swag             | Cleaning up challenges
swag             | Removing TXT record with name: _acme-challenge
swag             | Removing TXT record with name: _acme-challenge
swag             | IMPORTANT NOTES:
swag             |  - Congratulations! Your certificate and chain have been saved at:
swag             |    /etc/letsencrypt/live/mydomain.nl/fullchain.pem
swag             |    Your key file has been saved at:
swag             |    /etc/letsencrypt/live/mydomain.nl/privkey.pem
swag             |    Your certificate will expire on 2021-05-05. To obtain a new or
swag             |    tweaked version of this certificate in the future, simply run
swag             |    certbot again. To non-interactively renew *all* of your
swag             |    certificates, run "certbot renew"
swag             |  - If you like Certbot, please consider supporting our work by:
swag             | 
swag             |    Donating to ISRG / Let's Encrypt:   https://letsencrypt.org/donate
swag             |    Donating to EFF:                    https://eff.org/donate-le
swag             | 
swag             | New certificate generated; starting nginx
swag             | Starting 2019/12/30, GeoIP2 databases require personal license key to download. Please retrieve a free license key from MaxMind,
swag             | and add a new env variable "MAXMINDDB_LICENSE_KEY", set to your license key.
swag             | [cont-init.d] 50-config: exited 0.
swag             | [cont-init.d] 60-renew: executing... 
swag             | The cert does not expire within the next day. Letting the cron script handle the renewal attempts overnight (2:08am).
swag             | [cont-init.d] 60-renew: exited 0.
swag             | [cont-init.d] 70-templates: executing... 
swag             | [cont-init.d] 70-templates: exited 0.
swag             | [cont-init.d] 99-custom-files: executing... 
swag             | [custom-init] no custom files found exiting...
swag             | [cont-init.d] 99-custom-files: exited 0.
swag             | [cont-init.d] done.
swag             | [services.d] starting services
swag             | [services.d] done.
swag             | nginx: [alert] detected a LuaJIT version which is not OpenResty's; many optimizations will be disabled and performance will be compromised (see https://github.com/openresty/luajit2 for OpenResty's LuaJIT or, even better, consider using the OpenResty releases from https://openresty.org/en/download.html)
swag             | Server ready
```

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->

N.A.

Closes #82