### PR TITLE
Fix network resolution errors at startup

### DIFF
--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -280,6 +280,9 @@ else
   FILENAME="$DNSPLUGIN.ini"
 fi
 
+# wait some time to allow container's network to settle
+sleep 5
+
 # generating certs if necessary
 if [ ! -f "/config/keys/letsencrypt/fullchain.pem" ]; then
   if [ "$CERTPROVIDER" = "zerossl" ] && [ -n "$EMAIL" ]; then


### PR DESCRIPTION
Starting this container can fail at certbot initialization with this
error (reported at the end of /var/log/letsencrypt/letsencrypt.log):

   HTTPSConnectionPool(host='acme-v02.api.letsencrypt.org', port=443):
   Max retries exceeded with url: /directory "[Errno -3] Try again"

which sounds like a possible DNS resolution problem.

However, by logging into the container after the error above, a simple:

   wget https://acme-v02.api.letsencrypt.org/directory

usually works. It works also the exact same certbot command
logged in /var/log/letsencrypt/letsencrypt.log.

This has been verified happening while installing the contained on a
QNAP NAS with a bridged network setup.

Turns out that by adding a small delay right before running network
access operations (e.g. running certbot) fixes all the issues.
Likely a small sleep is good enough for the host/container to properly
setup the network stack.

Since this happens only at container startup, let's add a one-off 5s
sleep right before issuing the first certbot command.

Signed-off-by: Patrick Bellasi <patrick.bellasi@matbug.net>
