### PR TITLE
Redirect HTTP to HTTPS when using custom ports

### DIFF
--- a/root/defaults/ssl.conf
+++ b/root/defaults/ssl.conf
@@ -38,6 +38,9 @@ ssl_early_data on;
 # HSTS, remove # from the line below to enable HSTS
 #add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
 
+# Redirect http traffict to https on same port
+error_page 497 301 =307 https://$host:$server_port$request_uri;	
+
 # Optional additional headers
 #add_header Cache-Control "no-transform" always;
 #add_header Content-Security-Policy "upgrade-insecure-requests; frame-ancestors 'self'";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-swag/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
This configuration allows to redirect any HTTPs connection to HTTPS on the same port. 

When using custom ports, you currently get a 400 error if you're trying to access your server on `http://example.com:8080` instead of `https://example.com:8080`.

Redirect is done seamlessly.

I'm adding this config to the `ssl.conf` file because it needs to be included in every server configuration not just the main one (as I initially attempted), and this file is included in each website configuration.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Allows for HTTP to HTTPS redirection in every situation.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've tested it on my SWAG instance running on port 8080 externally with configs changed to serve 8080.
All my subdomains are behaving correctly and redirecting from http.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
