### PR TITLE
Add support for DirectAdmin DNS validation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,6 +101,7 @@ RUN \
 	certbot-dns-cloudxns \
 	certbot-dns-cpanel \
 	certbot-dns-digitalocean \
+	certbot-dns-directadmin \
 	certbot-dns-dnsimple \
 	certbot-dns-dnsmadeeasy \
 	certbot-dns-domeneshop \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -101,6 +101,7 @@ RUN \
 	certbot-dns-cloudxns \
 	certbot-dns-cpanel \
 	certbot-dns-digitalocean \
+	certbot-dns-directadmin \
 	certbot-dns-dnsimple \
 	certbot-dns-dnsmadeeasy \
 	certbot-dns-domeneshop \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -101,6 +101,7 @@ RUN \
 	certbot-dns-cloudxns \
 	certbot-dns-cpanel \
 	certbot-dns-digitalocean \
+	certbot-dns-directadmin \
 	certbot-dns-dnsimple \
 	certbot-dns-dnsmadeeasy \
 	certbot-dns-domeneshop \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -51,7 +51,7 @@ cap_add_param_vars:
 opt_param_usage_include_env: true
 opt_param_env_vars:
   - { env_var: "CERTPROVIDER", env_value: "", desc: "Optionally define the cert provider. Set to `zerossl` for ZeroSSL certs (requires existing [ZeroSSL account](https://app.zerossl.com/signup) and the e-mail address entered in `EMAIL` env var). Otherwise defaults to Let's Encrypt." }
-  - { env_var: "DNSPLUGIN", env_value: "cloudflare", desc: "Required if `VALIDATION` is set to `dns`. Options are `aliyun`, `cloudflare`, `cloudxns`, `cpanel`, `digitalocean`, `dnsimple`, `dnsmadeeasy`, `domeneshop`, `gandi`, `gehirn`, `google`, `hetzner`, `inwx`, `linode`, `luadns`, `netcup`, `njalla`, `nsone`, `ovh`, `rfc2136`, `route53`, `sakuracloud` and `transip`. Also need to enter the credentials into the corresponding ini (or json for some plugins) file under `/config/dns-conf`." }
+  - { env_var: "DNSPLUGIN", env_value: "cloudflare", desc: "Required if `VALIDATION` is set to `dns`. Options are `aliyun`, `cloudflare`, `cloudxns`, `cpanel`, `digitalocean`, `directadmin`, `dnsimple`, `dnsmadeeasy`, `domeneshop`, `gandi`, `gehirn`, `google`, `hetzner`, `inwx`, `linode`, `luadns`, `netcup`, `njalla`, `nsone`, `ovh`, `rfc2136`, `route53`, `sakuracloud` and `transip`. Also need to enter the credentials into the corresponding ini (or json for some plugins) file under `/config/dns-conf`." }
   - { env_var: "PROPAGATION", env_value: "", desc: "Optionally override (in seconds) the default propagation time for the dns plugins." }
   - { env_var: "DUCKDNSTOKEN", env_value: "", desc: "Required if `VALIDATION` is set to `duckdns`. Retrieve your token from https://www.duckdns.org" }
   - { env_var: "EMAIL", env_value: "", desc: "Optional e-mail address used for cert expiration notifications (Required for ZeroSSL)." }
@@ -151,6 +151,7 @@ app_setup_nginx_reverse_proxy_block: ""
 
 # changelog
 changelogs:
+  - { date: "14.03.21:", desc: "Add support for directadmin dns validation." }
   - { date: "12.02.21:", desc: "Clean up rust/cargo cache, which ballooned the image size in the last couple of builds." }
   - { date: "10.02.21:", desc: "Fix aliyun, domeneshop, inwx and transip dns confs for existing users." }
   - { date: "09.02.21:", desc: "Rebasing to alpine 3.13. Add nginx mods brotli and dav-ext. Remove nginx mods lua and lua-upstream (due to regression over the last couple of years)." }

--- a/root/defaults/dns-conf/directadmin.ini
+++ b/root/defaults/dns-conf/directadmin.ini
@@ -1,0 +1,21 @@
+# Instructions: https://github.com/cybercinch/certbot-dns-directadmin/blob/master/certbot_dns_directadmin/__init__.py
+
+# It is recommended to create a login key in the DirectAdmin control panel to be used as value for directadmin_password.
+# Instructions on how to create such key can be found at https://help.directadmin.com/item.php?id=523.
+#
+# Make sure to grant the following permissions:
+# - CMD_API_LOGIN_TEST
+# - CMD_API_DNS_CONTROL
+# - CMD_API_SHOW_DOMAINS
+#
+# Username and password can also be used in case your DirectAdmin instance has no support for login keys.
+
+# The DirectAdmin Server url
+# include the scheme and the port number (Normally 2222)
+directadmin_url = https://my.directadminserver.com:2222
+
+# The DirectAdmin username
+directadmin_username = username
+
+# The DirectAdmin password
+directadmin_password = aSuperStrongPassword

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -99,7 +99,7 @@ if ! grep -q 'PARAMETERS' "/config/nginx/dhparams.pem"; then
 fi
 
 # check to make sure DNSPLUGIN is selected if dns validation is used
-[[ "$VALIDATION" = "dns" ]] && [[ ! "$DNSPLUGIN" =~ ^(aliyun|cloudflare|cloudxns|cpanel|digitalocean|dnsimple|dnsmadeeasy|domeneshop|gandi|gehirn|google|hetzner|inwx|linode|luadns|netcup|njalla|nsone|ovh|rfc2136|route53|sakuracloud|transip)$ ]] && \
+[[ "$VALIDATION" = "dns" ]] && [[ ! "$DNSPLUGIN" =~ ^(aliyun|cloudflare|cloudxns|cpanel|digitalocean|directadmin|dnsimple|dnsmadeeasy|domeneshop|gandi|gehirn|google|hetzner|inwx|linode|luadns|netcup|njalla|nsone|ovh|rfc2136|route53|sakuracloud|transip)$ ]] && \
   echo "Please set the DNSPLUGIN variable to a valid plugin name. See docker info for more details." && \
   sleep infinity
 
@@ -216,6 +216,9 @@ if [ "$VALIDATION" = "dns" ]; then
   elif [[ "$DNSPLUGIN" =~ ^(aliyun|domeneshop|hetzner|inwx|netcup|njalla|transip)$ ]]; then
     if [ -n "$PROPAGATION" ];then PROPAGATIONPARAM="--dns-${DNSPLUGIN}-propagation-seconds ${PROPAGATION}"; fi
     PREFCHAL="-a dns-${DNSPLUGIN} --dns-${DNSPLUGIN}-credentials /config/dns-conf/${DNSPLUGIN}.ini ${PROPAGATIONPARAM}"
+  elif [[ "$DNSPLUGIN" =~ ^(directadmin)$ ]]; then
+    if [ -n "$PROPAGATION" ];then PROPAGATIONPARAM="--${DNSPLUGIN}-propagation-seconds ${PROPAGATION}"; fi
+    PREFCHAL="-a ${DNSPLUGIN} --${DNSPLUGIN}-credentials /config/dns-conf/${DNSPLUGIN}.ini ${PROPAGATIONPARAM}"
   else
     if [ -n "$PROPAGATION" ];then PROPAGATIONPARAM="--dns-${DNSPLUGIN}-propagation-seconds ${PROPAGATION}"; fi
     PREFCHAL="--dns-${DNSPLUGIN} --dns-${DNSPLUGIN}-credentials /config/dns-conf/${DNSPLUGIN}.ini ${PROPAGATIONPARAM}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-swag/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->

This PR adds support for DNS validation with DirectAdmin using plugin https://github.com/cybercinch/certbot-dns-directadmin

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

Currently it is not possible to perform DNS validation when a domain's DNS records are maintained on a (self-hosted) DirectAdmin instance.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Built the container, pushed to Docker Hub (https://hub.docker.com/r/simonlepla/swag) and tested it on my setup. Worked well (tested custom DNS propagation time as well).

Settings (docker-compose):
```
  swag:
    image: simonlepla/swag:directadmin
    container_name: swag
    environment:
      - PUID=1037
      - PGID=65538
      - TZ=Europe/Brussels
      - URL=www.example.com
      - VALIDATION=dns
      - DNSPLUGIN=directadmin
      - PROPAGATION=65
      - EMAIL=letsencrypt@example.com
    volumes:
      - /volume1/docker/swag/config:/config
    ports:
      - 443:443
      - 80:80
    restart: unless-stopped
```

Logs of the test (domain replaced with www.example.com):
```
[s6-init] making user provided files available at /var/run/s6/etc...exited 0.
[s6-init] ensuring user provided files have correct perms...exited 0.
[fix-attrs.d] applying ownership & permissions fixes...
[fix-attrs.d] done.
[cont-init.d] executing container initialization scripts...
[cont-init.d] 01-envfile: executing...
[cont-init.d] 01-envfile: exited 0.
[cont-init.d] 10-adduser: executing...

-------------------------------------
          _         ()
         | |  ___   _    __
         | | / __| | |  /  \
         | | \__ \ | | | () |
         |_| |___/ |_|  \__/


Brought to you by linuxserver.io
-------------------------------------

To support the app dev(s) visit:
Certbot: https://supporters.eff.org/donate/support-work-on-certbot

To support LSIO projects visit:
https://www.linuxserver.io/donate/
-------------------------------------
GID/UID
-------------------------------------

User uid:    1037
User gid:    65538
-------------------------------------

[cont-init.d] 10-adduser: exited 0.
[cont-init.d] 20-config: executing...
[cont-init.d] 20-config: exited 0.
[cont-init.d] 30-keygen: executing...
using keys found in /config/keys
[cont-init.d] 30-keygen: exited 0.
[cont-init.d] 50-config: executing...
Variables set:
PUID=1037
PGID=65538
TZ=Europe/Brussels
URL=www.example.com
SUBDOMAINS=
EXTRA_DOMAINS=
ONLY_SUBDOMAINS=false
VALIDATION=dns
CERTPROVIDER=
DNSPLUGIN=directadmin
EMAIL=letsencrypt@example.com
STAGING=

Using Let's Encrypt as the cert provider
No subdomains defined
E-mail address entered: letsencrypt@example.com
dns validation via directadmin plugin is selected
Different validation parameters entered than what was used before. Revoking and deleting existing certificate, and an updated one will be created
Saving debug log to /var/log/letsencrypt/letsencrypt.log
No match found for cert-path /config/etc/letsencrypt/live/www.example.com/fullchain.pem!
Generating new certificate
Saving debug log to /var/log/letsencrypt/letsencrypt.log
Plugins selected: Authenticator directadmin, Installer None
Account registered.
Requesting a certificate for www.example.com
Performing the following challenges:
dns-01 challenge for www.example.com
Unsafe permissions on credentials configuration file: /config/dns-conf/directadmin.ini
Successfully added TXT record for _acme-challenge.www.example.com
Waiting 65 seconds for DNS changes to propagate
Waiting for verification...
Cleaning up challenges
Successfully removed TXT record for _acme-challenge.www.example.com
IMPORTANT NOTES:
 - Congratulations! Your certificate and chain have been saved at:
   /etc/letsencrypt/live/www.example.com/fullchain.pem
   Your key file has been saved at:
New certificate generated; starting nginx
Starting 2019/12/30, GeoIP2 databases require personal license key to download. Please retrieve a free license key from MaxMind,
and add a new env variable "MAXMINDDB_LICENSE_KEY", set to your license key.
[cont-init.d] 50-config: exited 0.
[cont-init.d] 60-renew: executing...
The cert does not expire within the next day. Letting the cron script handle the renewal attempts overnight (2:08am).
[cont-init.d] 60-renew: exited 0.
[cont-init.d] 70-templates: executing...
[cont-init.d] 70-templates: exited 0.
[cont-init.d] 99-custom-files: executing...
[custom-init] no custom files found exiting...
[cont-init.d] 99-custom-files: exited 0.
[cont-init.d] done.
[services.d] starting services
[services.d] done.
Server ready
```

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->

https://github.com/cybercinch/certbot-dns-directadmin