### PR TITLE
feat(authelia): add remote name/email headers and pass http method

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -151,6 +151,7 @@ app_setup_nginx_reverse_proxy_block: ""
 
 # changelog
 changelogs:
+  - { date: "21.04.21:", desc: "[Existing users should update:](https://github.com/linuxserver/docker-swag/blob/master/README.md#updating-configs) authelia-server.conf and authelia-location.conf - Add remote name/email headers and pass http method." }
   - { date: "12.04.21:", desc: "Add php7-gmp and php7-pecl-mailparse." }
   - { date: "12.04.21:", desc: "Add support for vultr dns validation." }
   - { date: "14.03.21:", desc: "Add support for directadmin dns validation." }

--- a/root/defaults/authelia-location.conf
+++ b/root/defaults/authelia-location.conf
@@ -1,4 +1,4 @@
-## Version 2020/05/31 - Changelog: https://github.com/linuxserver/docker-swag/commits/master/root/defaults/authelia-location.conf
+## Version 2021/04/21 - Changelog: https://github.com/linuxserver/docker-swag/commits/master/root/defaults/authelia-location.conf
 # Make sure that your authelia container is in the same user defined bridge network and is named authelia
 # Make sure that the authelia configuration.yml has 'path: "authelia"' defined
 
@@ -6,6 +6,10 @@ auth_request /authelia/api/verify;
 auth_request_set $target_url $scheme://$http_host$request_uri;
 auth_request_set $user $upstream_http_remote_user;
 auth_request_set $groups $upstream_http_remote_groups;
+auth_request_set $name $upstream_http_remote_name;
+auth_request_set $email $upstream_http_remote_email;
 proxy_set_header Remote-User $user;
 proxy_set_header Remote-Groups $groups;
+proxy_set_header Remote-Name $name;
+proxy_set_header Remote-Email $email;
 error_page 401 =302 https://$http_host/authelia/?rd=$target_url;

--- a/root/defaults/authelia-server.conf
+++ b/root/defaults/authelia-server.conf
@@ -1,4 +1,4 @@
-## Version 2020/05/31 - Changelog: https://github.com/linuxserver/docker-swag/commits/master/root/defaults/authelia-server.conf
+## Version 2021/04/21 - Changelog: https://github.com/linuxserver/docker-swag/commits/master/root/defaults/authelia-server.conf
 # Make sure that your authelia container is in the same user defined bridge network and is named authelia
 
 location ^~ /authelia {
@@ -28,7 +28,8 @@ location = /authelia/api/verify {
     proxy_set_header Host $host;
     proxy_set_header X-Original-URL $scheme://$http_host$request_uri;
     proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $remote_addr; 
+    proxy_set_header X-Forwarded-For $remote_addr;
+    proxy_set_header X-Forwarded-Method $request_method;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-Forwarded-Uri $request_uri;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-swag/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
This adds newer remote credential information from the auth_request headers sent by Authelia, Remote-Name includes the users display name, and Remote-Email includes their email. Additionally it sets the X-Forwarded-Method header to the original $request_method detected by nginx, which is used for the new acl rule method filter.

## Benefits of this PR and context:
Adds the new features of the upstream project (Authelia) to the config templates.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This is tested in integration testing upstream. However this has **NOT** been tested specifically with LSIO's swag image or this specific configuration.

## Source / References:
https://www.authelia.com/docs/deployment/supported-proxies/nginx.html
