### PR TITLE
Renewal hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ This will *ask* Google et al not to index and list your site. Be careful with th
 * You can check which jails are active via `docker exec -it swag fail2ban-client status`
 * You can check the status of a specific jail via `docker exec -it swag fail2ban-client status <jail name>`
 * You can unban an IP via `docker exec -it swag fail2ban-client set <jail name> unbanip <IP>`
-* A list of commands can be found here: https://www.fail2ban.org/wiki/index.php/Commands
+* A list of commands can be found here: <https://www.fail2ban.org/wiki/index.php/Commands>
 
 ### Updating configs
 
@@ -131,6 +131,7 @@ This will *ask* Google et al not to index and list your site. Be careful with th
 * You can check the new sample and adjust your active config as needed.
 
 ### Migration from the old `linuxserver/letsencrypt` image
+
 Please follow the instructions [on this blog post](https://www.linuxserver.io/blog/2020-08-21-introducing-swag#migrate).
 
 ## Usage
@@ -211,11 +212,11 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e TZ=Europe/London` | Specify a timezone to use EG Europe/London. |
 | `-e URL=yourdomain.url` | Top url you have control over (`customdomain.com` if you own it, or `customsubdomain.ddnsprovider.com` if dynamic dns). |
 | `-e VALIDATION=http` | Certbot validation method to use, options are `http`, `dns` or `duckdns` (`dns` method also requires `DNSPLUGIN` variable set) (`duckdns` method requires `DUCKDNSTOKEN` variable set, and the `SUBDOMAINS` variable must be either empty or set to `wildcard`). |
-| `-e SUBDOMAINS=www,` | Subdomains you'd like the cert to cover (comma separated, no spaces) ie. `www,ftp,cloud`. For a wildcard cert, set this _exactly_ to `wildcard` (wildcard cert is available via `dns` and `duckdns` validation only) |
+| `-e SUBDOMAINS=www,` | Subdomains you'd like the cert to cover (comma separated, no spaces) ie. `www,ftp,cloud`. For a wildcard cert, set this *exactly* to `wildcard` (wildcard cert is available via `dns` and `duckdns` validation only) |
 | `-e CERTPROVIDER=` | Optionally define the cert provider. Set to `zerossl` for ZeroSSL certs (requires existing [ZeroSSL account](https://app.zerossl.com/signup) and the e-mail address entered in `EMAIL` env var). Otherwise defaults to Let's Encrypt. |
 | `-e DNSPLUGIN=cloudflare` | Required if `VALIDATION` is set to `dns`. Options are `acmedns`, `aliyun`, `azure`, `cloudflare`, `cloudxns`, `cpanel`, `desec`, `digitalocean`, `directadmin`, `dnsimple`, `dnsmadeeasy`, `dnspod`, `do`, `domeneshop`, `dynu`, `gandi`, `gehirn`, `godaddy`, `google`, `he`, `hetzner`, `infomaniak`, `inwx`, `ionos`, `linode`, `loopia`, `luadns`, `netcup`, `njalla`, `nsone`, `ovh`, `porkbun`, `rfc2136`, `route53`, `sakuracloud`, `standalone`, `transip`, and `vultr`. Also need to enter the credentials into the corresponding ini (or json for some plugins) file under `/config/dns-conf`. |
 | `-e PROPAGATION=` | Optionally override (in seconds) the default propagation time for the dns plugins. |
-| `-e DUCKDNSTOKEN=` | Required if `VALIDATION` is set to `duckdns`. Retrieve your token from https://www.duckdns.org |
+| `-e DUCKDNSTOKEN=` | Required if `VALIDATION` is set to `duckdns`. Retrieve your token from <https://www.duckdns.org> |
 | `-e EMAIL=` | Optional e-mail address used for cert expiration notifications (Required for ZeroSSL). |
 | `-e ONLY_SUBDOMAINS=false` | If you wish to get certs only for certain subdomains, but not the main domain (main domain may be hosted on another machine and cannot be validated), set this to `true` |
 | `-e EXTRA_DOMAINS=` | Additional fully qualified domain names (comma separated, no spaces) ie. `extradomain.com,subdomain.anotherdomain.org,*.anotherdomain.org` |
@@ -335,6 +336,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **05.10.22:** - Use certbot file hooks instead of command line hooks
 * **04.10.22:** - Add godaddy and porkbun dns plugins.
 * **03.10.22:** - Add default_server back to default site conf's https listen.
 * **22.09.22:** - Added support for DO DNS validation.
@@ -351,7 +353,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 * **22.11.21:** - Added support for Infomaniak DNS for certificate generation.
 * **20.11.21:** - Added support for dnspod validation.
 * **15.11.21:** - Added support for deSEC DNS for wildcard certificate generation.
-* **26.10.21:** - [Existing users should update:](https://github.com/linuxserver/docker-swag/blob/master/README.md#updating-configs) proxy.conf - Mitigate https://httpoxy.org/ vulnerabilities. Ref: https://www.nginx.com/blog/mitigating-the-httpoxy-vulnerability-with-nginx#Defeating-the-Attack-using-NGINX-and-NGINX-Plus
+* **26.10.21:** - [Existing users should update:](https://github.com/linuxserver/docker-swag/blob/master/README.md#updating-configs) proxy.conf - Mitigate <https://httpoxy.org/> vulnerabilities. Ref: <https://www.nginx.com/blog/mitigating-the-httpoxy-vulnerability-with-nginx#Defeating-the-Attack-using-NGINX-and-NGINX-Plus>
 * **23.10.21:** - Fix Hurricane Electric (HE) DNS validation.
 * **12.10.21:** - Fix deprecated LE root cert check to fix failures when using `STAGING=true`, and failures in revoking.
 * **06.10.21:** - Added support for Hurricane Electric (HE) DNS validation. Added lxml build deps.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -49,11 +49,11 @@ cap_add_param_vars:
 # optional container parameters
 opt_param_usage_include_env: true
 opt_param_env_vars:
-  - { env_var: "SUBDOMAINS", env_value: "www,", desc: "Subdomains you'd like the cert to cover (comma separated, no spaces) ie. `www,ftp,cloud`. For a wildcard cert, set this _exactly_ to `wildcard` (wildcard cert is available via `dns` and `duckdns` validation only)" }
+  - { env_var: "SUBDOMAINS", env_value: "www,", desc: "Subdomains you'd like the cert to cover (comma separated, no spaces) ie. `www,ftp,cloud`. For a wildcard cert, set this *exactly* to `wildcard` (wildcard cert is available via `dns` and `duckdns` validation only)" }
   - { env_var: "CERTPROVIDER", env_value: "", desc: "Optionally define the cert provider. Set to `zerossl` for ZeroSSL certs (requires existing [ZeroSSL account](https://app.zerossl.com/signup) and the e-mail address entered in `EMAIL` env var). Otherwise defaults to Let's Encrypt." }
   - { env_var: "DNSPLUGIN", env_value: "cloudflare", desc: "Required if `VALIDATION` is set to `dns`. Options are `acmedns`, `aliyun`, `azure`, `cloudflare`, `cloudxns`, `cpanel`, `desec`, `digitalocean`, `directadmin`, `dnsimple`, `dnsmadeeasy`, `dnspod`, `do`, `domeneshop`, `dynu`, `gandi`, `gehirn`, `godaddy`, `google`, `he`, `hetzner`, `infomaniak`, `inwx`, `ionos`, `linode`, `loopia`, `luadns`, `netcup`, `njalla`, `nsone`, `ovh`, `porkbun`, `rfc2136`, `route53`, `sakuracloud`, `standalone`, `transip`, and `vultr`. Also need to enter the credentials into the corresponding ini (or json for some plugins) file under `/config/dns-conf`." }
   - { env_var: "PROPAGATION", env_value: "", desc: "Optionally override (in seconds) the default propagation time for the dns plugins." }
-  - { env_var: "DUCKDNSTOKEN", env_value: "", desc: "Required if `VALIDATION` is set to `duckdns`. Retrieve your token from https://www.duckdns.org" }
+  - { env_var: "DUCKDNSTOKEN", env_value: "", desc: "Required if `VALIDATION` is set to `duckdns`. Retrieve your token from <https://www.duckdns.org>" }
   - { env_var: "EMAIL", env_value: "", desc: "Optional e-mail address used for cert expiration notifications (Required for ZeroSSL)." }
   - { env_var: "ONLY_SUBDOMAINS", env_value: "false", desc: "If you wish to get certs only for certain subdomains, but not the main domain (main domain may be hosted on another machine and cannot be validated), set this to `true`" }
   - { env_var: "EXTRA_DOMAINS", env_value: "", desc: "Additional fully qualified domain names (comma separated, no spaces) ie. `extradomain.com,subdomain.anotherdomain.org,*.anotherdomain.org`" }
@@ -131,7 +131,7 @@ app_setup_block: |
   * You can check which jails are active via `docker exec -it swag fail2ban-client status`
   * You can check the status of a specific jail via `docker exec -it swag fail2ban-client status <jail name>`
   * You can unban an IP via `docker exec -it swag fail2ban-client set <jail name> unbanip <IP>`
-  * A list of commands can be found here: https://www.fail2ban.org/wiki/index.php/Commands
+  * A list of commands can be found here: <https://www.fail2ban.org/wiki/index.php/Commands>
 
   ### Updating configs
 
@@ -148,6 +148,7 @@ app_setup_block: |
   * You can check the new sample and adjust your active config as needed.
 
   ### Migration from the old `linuxserver/letsencrypt` image
+
   Please follow the instructions [on this blog post](https://www.linuxserver.io/blog/2020-08-21-introducing-swag#migrate).
 
 app_setup_nginx_reverse_proxy_snippet: false
@@ -155,6 +156,7 @@ app_setup_nginx_reverse_proxy_block: ""
 
 # changelog
 changelogs:
+  - { date: "05.10.22:", desc: "Use certbot file hooks instead of command line hooks" }
   - { date: "04.10.22:", desc: "Add godaddy and porkbun dns plugins." }
   - { date: "03.10.22:", desc: "Add default_server back to default site conf's https listen." }
   - { date: "22.09.22:", desc: "Added support for DO DNS validation." }
@@ -171,7 +173,7 @@ changelogs:
   - { date: "22.11.21:", desc: "Added support for Infomaniak DNS for certificate generation." }
   - { date: "20.11.21:", desc: "Added support for dnspod validation." }
   - { date: "15.11.21:", desc: "Added support for deSEC DNS for wildcard certificate generation." }
-  - { date: "26.10.21:", desc: "[Existing users should update:](https://github.com/linuxserver/docker-swag/blob/master/README.md#updating-configs) proxy.conf - Mitigate https://httpoxy.org/ vulnerabilities. Ref: https://www.nginx.com/blog/mitigating-the-httpoxy-vulnerability-with-nginx#Defeating-the-Attack-using-NGINX-and-NGINX-Plus" }
+  - { date: "26.10.21:", desc: "[Existing users should update:](https://github.com/linuxserver/docker-swag/blob/master/README.md#updating-configs) proxy.conf - Mitigate <https://httpoxy.org/> vulnerabilities. Ref: <https://www.nginx.com/blog/mitigating-the-httpoxy-vulnerability-with-nginx#Defeating-the-Attack-using-NGINX-and-NGINX-Plus>" }
   - { date: "23.10.21:", desc: "Fix Hurricane Electric (HE) DNS validation." }
   - { date: "12.10.21:", desc: "Fix deprecated LE root cert check to fix failures when using `STAGING=true`, and failures in revoking." }
   - { date: "06.10.21:", desc: "Added support for Hurricane Electric (HE) DNS validation. Added lxml build deps." }

--- a/root/app/le-renew.sh
+++ b/root/app/le-renew.sh
@@ -1,27 +1,8 @@
 #!/usr/bin/with-contenv bash
 
-. /config/.donoteditthisfile.conf
-
 echo "<------------------------------------------------->"
 echo
 echo "<------------------------------------------------->"
-echo "cronjob running on "$(date)
+echo "cronjob running on $(date)"
 echo "Running certbot renew"
-if [ "$ORIGVALIDATION" = "dns" ] || [ "$ORIGVALIDATION" = "duckdns" ]; then
-  certbot -n renew \
-    --post-hook "if ps aux | grep [n]ginx: > /dev/null; then s6-svc -h /var/run/s6/services/nginx; fi; \
-    cd /config/keys/letsencrypt && \
-    openssl pkcs12 -export -out privkey.pfx -inkey privkey.pem -in cert.pem -certfile chain.pem -passout pass: && \
-    sleep 1 && \
-    cat privkey.pem fullchain.pem > priv-fullchain-bundle.pem && \
-    chown -R abc:abc /config/etc/letsencrypt"
-else
-  certbot -n renew \
-    --pre-hook "if ps aux | grep [n]ginx: > /dev/null; then s6-svc -d /var/run/s6/services/nginx; fi" \
-    --post-hook "if ps aux | grep 's6-supervise nginx' | grep -v grep > /dev/null; then s6-svc -u /var/run/s6/services/nginx; fi; \
-    cd /config/keys/letsencrypt && \
-    openssl pkcs12 -export -out privkey.pfx -inkey privkey.pem -in cert.pem -certfile chain.pem -passout pass: && \
-    sleep 1 && \
-    cat privkey.pem fullchain.pem > priv-fullchain-bundle.pem && \
-    chown -R abc:abc /config/etc/letsencrypt"
-fi
+certbot renew --non-interactive

--- a/root/defaults/etc/letsencrypt/renewal-hooks/deploy/10-default
+++ b/root/defaults/etc/letsencrypt/renewal-hooks/deploy/10-default
@@ -1,0 +1,7 @@
+#!/usr/bin/with-contenv bash
+
+cd /config/keys/letsencrypt || exit 1
+openssl pkcs12 -export -out privkey.pfx -inkey privkey.pem -in cert.pem -certfile chain.pem -passout pass:
+sleep 1
+cat {privkey,fullchain}.pem >priv-fullchain-bundle.pem
+chown -R abc:abc /config/etc/letsencrypt

--- a/root/defaults/etc/letsencrypt/renewal-hooks/post/10-nginx
+++ b/root/defaults/etc/letsencrypt/renewal-hooks/post/10-nginx
@@ -1,0 +1,13 @@
+#!/usr/bin/with-contenv bash
+
+. /config/.donoteditthisfile.conf
+
+if [ ! "$ORIGVALIDATION" = "dns" ] && [ ! "$ORIGVALIDATION" = "duckdns" ]; then
+	if ps aux | grep 's6-supervise nginx' | grep -v grep >/dev/null; then
+		s6-svc -u /run/service/nginx
+	fi
+else
+	if ps aux | grep [n]ginx: >/dev/null; then
+		s6-svc -h /run/service/nginx
+	fi
+fi

--- a/root/defaults/etc/letsencrypt/renewal-hooks/pre/10-nginx
+++ b/root/defaults/etc/letsencrypt/renewal-hooks/pre/10-nginx
@@ -1,0 +1,9 @@
+#!/usr/bin/with-contenv bash
+
+. /config/.donoteditthisfile.conf
+
+if [ ! "$ORIGVALIDATION" = "dns" ] && [ ! "$ORIGVALIDATION" = "duckdns" ]; then
+	if ps aux | grep [n]ginx: >/dev/null; then
+		s6-svc -d /run/service/nginx
+	fi
+fi

--- a/root/etc/cont-init.d/40-folders
+++ b/root/etc/cont-init.d/40-folders
@@ -3,9 +3,9 @@
 # make our folders and links
 mkdir -p \
     /config/{fail2ban,crontabs,dns-conf} \
-    /config/etc/letsencrypt \
+    /config/etc/letsencrypt/renewal-hooks \
     /config/log/{fail2ban,letsencrypt,nginx} \
     /config/nginx/proxy-confs \
-    /var/run/fail2ban
+    /run/fail2ban
 rm -rf /etc/letsencrypt
 ln -s /config/etc/letsencrypt /etc/letsencrypt

--- a/root/etc/cont-init.d/50-certbot
+++ b/root/etc/cont-init.d/50-certbot
@@ -16,30 +16,39 @@ EMAIL=${EMAIL}\\n\
 STAGING=${STAGING}\\n"
 
 # Sanitize variables
-SANED_VARS=( DNSPLUGIN EMAIL EXTRA_DOMAINS ONLY_SUBDOMAINS STAGING SUBDOMAINS URL VALIDATION CERTPROVIDER )
-for i in "${SANED_VARS[@]}"
-do
+SANED_VARS=(DNSPLUGIN EMAIL EXTRA_DOMAINS ONLY_SUBDOMAINS STAGING SUBDOMAINS URL VALIDATION CERTPROVIDER)
+for i in "${SANED_VARS[@]}"; do
     export echo "$i"="${!i//\"/}"
     export echo "$i"="$(echo "${!i}" | tr '[:upper:]' '[:lower:]')"
 done
-
-# copy dns default configs
-cp -n /defaults/dns-conf/* /config/dns-conf/
-chown -R abc:abc /config/dns-conf
 
 # check to make sure DNSPLUGIN is selected if dns validation is used
 if [[ "$VALIDATION" = "dns" ]] && [[ ! "$DNSPLUGIN" =~ ^(acmedns|aliyun|azure|cloudflare|cloudxns|cpanel|desec|digitalocean|directadmin|dnsimple|dnsmadeeasy|dnspod|do|domeneshop|dynu|gandi|gehirn|godaddy|google|he|hetzner|infomaniak|inwx|ionos|linode|loopia|luadns|netcup|njalla|nsone|ovh|porkbun|rfc2136|route53|sakuracloud|standalone|transip|vultr)$ ]]; then
     echo "Please set the DNSPLUGIN variable to a valid plugin name. See docker info for more details."
     sleep infinity
-
 fi
+
+# copy dns default configs
+cp -n /defaults/dns-conf/* /config/dns-conf/
+chown -R abc:abc /config/dns-conf
+
+# update plugin names in dns conf inis
+sed -i 's|^certbot_dns_aliyun:||g' /config/dns-conf/aliyun.ini
+sed -i 's|^certbot_dns_domeneshop:||g' /config/dns-conf/domeneshop.ini
+sed -i 's|^certbot_dns_inwx:||g' /config/dns-conf/inwx.ini
+sed -i 's|^certbot_dns_transip:||g' /config/dns-conf/transip.ini
+
+# copy default renewal hooks
+chmod -R +x /defaults/etc/letsencrypt/renewal-hooks
+cp -nR /defaults/etc/letsencrypt/renewal-hooks/* /config/etc/letsencrypt/renewal-hooks/
+chown -R abc:abc /config/etc/letsencrypt/renewal-hooks
 
 # create original config file if it doesn't exist, move non-hidden legacy file to hidden
 if [ -f "/config/donoteditthisfile.conf" ]; then
     mv /config/donoteditthisfile.conf /config/.donoteditthisfile.conf
 fi
 if [ ! -f "/config/.donoteditthisfile.conf" ]; then
-    echo -e "ORIGURL=\"$URL\" ORIGSUBDOMAINS=\"$SUBDOMAINS\" ORIGONLY_SUBDOMAINS=\"$ONLY_SUBDOMAINS\" ORIGEXTRA_DOMAINS=\"$EXTRA_DOMAINS\" ORIGVALIDATION=\"$VALIDATION\" ORIGDNSPLUGIN=\"$DNSPLUGIN\" ORIGPROPAGATION=\"$PROPAGATION\" ORIGSTAGING=\"$STAGING\" ORIGDUCKDNSTOKEN=\"$DUCKDNSTOKEN\" ORIGCERTPROVIDER=\"$CERTPROVIDER\" ORIGEMAIL=\"$EMAIL\"" > /config/.donoteditthisfile.conf
+    echo -e "ORIGURL=\"$URL\" ORIGSUBDOMAINS=\"$SUBDOMAINS\" ORIGONLY_SUBDOMAINS=\"$ONLY_SUBDOMAINS\" ORIGEXTRA_DOMAINS=\"$EXTRA_DOMAINS\" ORIGVALIDATION=\"$VALIDATION\" ORIGDNSPLUGIN=\"$DNSPLUGIN\" ORIGPROPAGATION=\"$PROPAGATION\" ORIGSTAGING=\"$STAGING\" ORIGDUCKDNSTOKEN=\"$DUCKDNSTOKEN\" ORIGCERTPROVIDER=\"$CERTPROVIDER\" ORIGEMAIL=\"$EMAIL\"" >/config/.donoteditthisfile.conf
     echo "Created .donoteditthisfile.conf"
 fi
 
@@ -120,40 +129,34 @@ else
     EMAILPARAM="--register-unsafely-without-email"
 fi
 
-# update plugin names in dns conf inis
-sed -i 's|^certbot_dns_aliyun:||g' /config/dns-conf/aliyun.ini
-sed -i 's|^certbot_dns_domeneshop:||g' /config/dns-conf/domeneshop.ini
-sed -i 's|^certbot_dns_inwx:||g' /config/dns-conf/inwx.ini
-sed -i 's|^certbot_dns_transip:||g' /config/dns-conf/transip.ini
-
 # setting the validation method to use
 if [ "$VALIDATION" = "dns" ]; then
     if [ "$DNSPLUGIN" = "route53" ]; then
-        if [ -n "$PROPAGATION" ];then PROPAGATIONPARAM="--dns-${DNSPLUGIN}-propagation-seconds ${PROPAGATION}"; fi
+        if [ -n "$PROPAGATION" ]; then PROPAGATIONPARAM="--dns-${DNSPLUGIN}-propagation-seconds ${PROPAGATION}"; fi
         PREFCHAL="--dns-${DNSPLUGIN} ${PROPAGATIONPARAM}"
     elif [[ "$DNSPLUGIN" =~ ^(cpanel)$ ]]; then
-        if [ -n "$PROPAGATION" ];then PROPAGATIONPARAM="--certbot-dns-${DNSPLUGIN}:${DNSPLUGIN}-propagation-seconds ${PROPAGATION}"; fi
+        if [ -n "$PROPAGATION" ]; then PROPAGATIONPARAM="--certbot-dns-${DNSPLUGIN}:${DNSPLUGIN}-propagation-seconds ${PROPAGATION}"; fi
         PREFCHAL="-a certbot-dns-${DNSPLUGIN}:${DNSPLUGIN} --certbot-dns-${DNSPLUGIN}:${DNSPLUGIN}-credentials /config/dns-conf/${DNSPLUGIN}.ini ${PROPAGATIONPARAM}"
     elif [[ "$DNSPLUGIN" =~ ^(gandi)$ ]]; then
-        if [ -n "$PROPAGATION" ];then echo "Gandi dns plugin does not support setting propagation time"; fi
+        if [ -n "$PROPAGATION" ]; then echo "Gandi dns plugin does not support setting propagation time"; fi
         PREFCHAL="-a certbot-plugin-${DNSPLUGIN}:dns --certbot-plugin-${DNSPLUGIN}:dns-credentials /config/dns-conf/${DNSPLUGIN}.ini"
     elif [[ "$DNSPLUGIN" =~ ^(google)$ ]]; then
-        if [ -n "$PROPAGATION" ];then PROPAGATIONPARAM="--dns-${DNSPLUGIN}-propagation-seconds ${PROPAGATION}"; fi
+        if [ -n "$PROPAGATION" ]; then PROPAGATIONPARAM="--dns-${DNSPLUGIN}-propagation-seconds ${PROPAGATION}"; fi
         PREFCHAL="--dns-${DNSPLUGIN} --dns-${DNSPLUGIN}-credentials /config/dns-conf/${DNSPLUGIN}.json ${PROPAGATIONPARAM}"
     elif [[ "$DNSPLUGIN" =~ ^(aliyun|desec|dnspod|do|domeneshop|dynu|godaddy|he|hetzner|infomaniak|inwx|ionos|loopia|netcup|njalla|porkbun|transip|vultr)$ ]]; then
-        if [ -n "$PROPAGATION" ];then PROPAGATIONPARAM="--dns-${DNSPLUGIN}-propagation-seconds ${PROPAGATION}"; fi
+        if [ -n "$PROPAGATION" ]; then PROPAGATIONPARAM="--dns-${DNSPLUGIN}-propagation-seconds ${PROPAGATION}"; fi
         PREFCHAL="-a dns-${DNSPLUGIN} --dns-${DNSPLUGIN}-credentials /config/dns-conf/${DNSPLUGIN}.ini ${PROPAGATIONPARAM}"
     elif [[ "$DNSPLUGIN" =~ ^(standalone)$ ]]; then
-        if [ -n "$PROPAGATION" ];then echo "standalone dns plugin does not support setting propagation time"; fi
+        if [ -n "$PROPAGATION" ]; then echo "standalone dns plugin does not support setting propagation time"; fi
         PREFCHAL="-a dns-${DNSPLUGIN}"
     elif [[ "$DNSPLUGIN" =~ ^(directadmin)$ ]]; then
-        if [ -n "$PROPAGATION" ];then PROPAGATIONPARAM="--${DNSPLUGIN}-propagation-seconds ${PROPAGATION}"; fi
+        if [ -n "$PROPAGATION" ]; then PROPAGATIONPARAM="--${DNSPLUGIN}-propagation-seconds ${PROPAGATION}"; fi
         PREFCHAL="-a ${DNSPLUGIN} --${DNSPLUGIN}-credentials /config/dns-conf/${DNSPLUGIN}.ini ${PROPAGATIONPARAM}"
     elif [[ "$DNSPLUGIN" =~ ^(azure)$ ]]; then
-        if [ -n "$PROPAGATION" ];then echo "Azure dns plugin does not support setting propagation time"; fi
+        if [ -n "$PROPAGATION" ]; then echo "Azure dns plugin does not support setting propagation time"; fi
         PREFCHAL="-a dns-${DNSPLUGIN} --dns-${DNSPLUGIN}-credentials /config/dns-conf/${DNSPLUGIN}.ini"
     else
-        if [ -n "$PROPAGATION" ];then PROPAGATIONPARAM="--dns-${DNSPLUGIN}-propagation-seconds ${PROPAGATION}"; fi
+        if [ -n "$PROPAGATION" ]; then PROPAGATIONPARAM="--dns-${DNSPLUGIN}-propagation-seconds ${PROPAGATION}"; fi
         PREFCHAL="--dns-${DNSPLUGIN} --dns-${DNSPLUGIN}-credentials /config/dns-conf/${DNSPLUGIN}.ini ${PROPAGATIONPARAM}"
     fi
     echo "${VALIDATION} validation via ${DNSPLUGIN} plugin is selected"
@@ -178,7 +181,7 @@ fi
 
 # setting the symlink for key location
 rm -rf /config/keys/letsencrypt
-if [ "$ONLY_SUBDOMAINS" = "true" ] && [ ! "$SUBDOMAINS" = "wildcard" ] ; then
+if [ "$ONLY_SUBDOMAINS" = "true" ] && [ ! "$SUBDOMAINS" = "wildcard" ]; then
     DOMAIN="$(echo "$SUBDOMAINS" | tr ',' ' ' | awk '{print $1}').${URL}"
     ln -s ../etc/letsencrypt/live/"$DOMAIN" /config/keys/letsencrypt
 else
@@ -214,12 +217,11 @@ if [ ! "$URL" = "$ORIGURL" ] || [ ! "$SUBDOMAINS" = "$ORIGSUBDOMAINS" ] || [ ! "
     if [[ -f /config/etc/letsencrypt/live/"$ORIGDOMAIN"/fullchain.pem ]]; then
         certbot revoke --non-interactive --cert-path /config/etc/letsencrypt/live/"$ORIGDOMAIN"/fullchain.pem --server $REV_ACMESERVER
     fi
-    rm -rf /config/etc/letsencrypt
-    mkdir -p /config/etc/letsencrypt
+    rm -rf /config/etc/letsencrypt/{archive,live,renewal}
 fi
 
 # saving new variables
-echo -e "ORIGURL=\"$URL\" ORIGSUBDOMAINS=\"$SUBDOMAINS\" ORIGONLY_SUBDOMAINS=\"$ONLY_SUBDOMAINS\" ORIGEXTRA_DOMAINS=\"$EXTRA_DOMAINS\" ORIGVALIDATION=\"$VALIDATION\" ORIGDNSPLUGIN=\"$DNSPLUGIN\" ORIGPROPAGATION=\"$PROPAGATION\" ORIGSTAGING=\"$STAGING\" ORIGDUCKDNSTOKEN=\"$DUCKDNSTOKEN\" ORIGCERTPROVIDER=\"$CERTPROVIDER\" ORIGEMAIL=\"$EMAIL\"" > /config/.donoteditthisfile.conf
+echo -e "ORIGURL=\"$URL\" ORIGSUBDOMAINS=\"$SUBDOMAINS\" ORIGONLY_SUBDOMAINS=\"$ONLY_SUBDOMAINS\" ORIGEXTRA_DOMAINS=\"$EXTRA_DOMAINS\" ORIGVALIDATION=\"$VALIDATION\" ORIGDNSPLUGIN=\"$DNSPLUGIN\" ORIGPROPAGATION=\"$PROPAGATION\" ORIGSTAGING=\"$STAGING\" ORIGDUCKDNSTOKEN=\"$DUCKDNSTOKEN\" ORIGCERTPROVIDER=\"$CERTPROVIDER\" ORIGEMAIL=\"$EMAIL\"" >/config/.donoteditthisfile.conf
 
 # alter extension for error message
 if [ "$DNSPLUGIN" = "google" ]; then
@@ -229,12 +231,11 @@ else
 fi
 
 # Check if the cert is using the old LE root cert, revoke and regen if necessary
-if [ -f "/config/keys/letsencrypt/chain.pem" ] && ([ "${CERTPROVIDER}" == "letsencrypt" ] || [ "${CERTPROVIDER}" == "" ]) && [ "${STAGING}" != "true" ] && ! openssl x509 -in /config/keys/letsencrypt/chain.pem -noout -issuer | grep -q "ISRG Root X"; then
+if [ -f "/config/keys/letsencrypt/chain.pem" ] && { [ "${CERTPROVIDER}" == "letsencrypt" ] || [ "${CERTPROVIDER}" == "" ]; } && [ "${STAGING}" != "true" ] && ! openssl x509 -in /config/keys/letsencrypt/chain.pem -noout -issuer | grep -q "ISRG Root X"; then
     echo "The cert seems to be using the old LE root cert, which is no longer valid. Deleting and revoking."
     REV_ACMESERVER="https://acme-v02.api.letsencrypt.org/directory"
     certbot revoke --non-interactive --cert-path /config/etc/letsencrypt/live/"$ORIGDOMAIN"/fullchain.pem --server $REV_ACMESERVER
-    rm -rf /config/etc/letsencrypt
-    mkdir -p /config/etc/letsencrypt
+    rm -rf /config/etc/letsencrypt/{archive,live,renewal}
 fi
 
 # generating certs if necessary
@@ -252,10 +253,8 @@ if [ ! -f "/config/keys/letsencrypt/fullchain.pem" ]; then
     fi
     echo "Generating new certificate"
     # shellcheck disable=SC2086
-    certbot certonly --renew-by-default --server $ACMESERVER $ZEROSSL_EAB $PREFCHAL --rsa-key-size 4096 $EMAILPARAM --agree-tos $URL_REAL
-    if [ -d /config/keys/letsencrypt ]; then
-        cd /config/keys/letsencrypt || exit
-    else
+    certbot certonly --non-interactive --renew-by-default --server $ACMESERVER $ZEROSSL_EAB $PREFCHAL --rsa-key-size 4096 $EMAILPARAM --agree-tos $URL_REAL
+    if [ ! -d /config/keys/letsencrypt ]; then
         if [ "$VALIDATION" = "dns" ]; then
             echo "ERROR: Cert does not exist! Please see the validation error above. Make sure you entered correct credentials into the /config/dns-conf/${FILENAME} file."
         elif [ "$VALIDATION" = "duckdns" ]; then
@@ -265,9 +264,7 @@ if [ ! -f "/config/keys/letsencrypt/fullchain.pem" ]; then
         fi
         sleep infinity
     fi
-    openssl pkcs12 -export -out privkey.pfx -inkey privkey.pem -in cert.pem -certfile chain.pem -passout pass:
-    sleep 1
-    cat {privkey,fullchain}.pem > priv-fullchain-bundle.pem
+    run-parts /config/etc/letsencrypt/renewal-hooks/deploy/
     echo "New certificate generated; starting nginx"
 else
     echo "Certificate exists; parameters unchanged; starting nginx"


### PR DESCRIPTION
This supersedes https://github.com/linuxserver/docker-swag/pull/89

The changes here use the default location that already exists for hooks (`/config/etc/letsencrypt/renewal-hooks`) and remove the suggestions in the documentation for users to make changes.

Essentially, the feature will exist undocumented.

Will need to rebase after https://github.com/linuxserver/docker-swag/pull/169