### PR TITLE
fix old root detection (staging and acme server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **12.10.21:** - Fix deprecated LE root cert check to fix failures when using `STAGING=true`, and failures in revoking.
 * **06.10.21:** - Added support for Hurricane Electric (HE) DNS validation. Added lxml build deps.
 * **01.10.21:** - Check if the cert uses the old LE root cert, revoke and regenerate if necessary. [Here's more info](https://twitter.com/letsencrypt/status/1443621997288767491) on LE root cert expiration
 * **19.09.21:** - Add an optional header to opt out of Google FLoC in `ssl.conf`.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -155,6 +155,7 @@ app_setup_nginx_reverse_proxy_block: ""
 
 # changelog
 changelogs:
+  - { date: "12.10.21:", desc: "Fix deprecated LE root cert check to fix failures when using `STAGING=true`, and failures in revoking." }
   - { date: "06.10.21:", desc: "Added support for Hurricane Electric (HE) DNS validation. Added lxml build deps." }
   - { date: "01.10.21:", desc: "Check if the cert uses the old LE root cert, revoke and regenerate if necessary. [Here's more info](https://twitter.com/letsencrypt/status/1443621997288767491) on LE root cert expiration" }
   - { date: "19.09.21:", desc: "Add an optional header to opt out of Google FLoC in `ssl.conf`." }

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -313,8 +313,9 @@ else
 fi
 
 # Check if the cert is using the old LE root cert, revoke and regen if necessary
-if [ -f "/config/keys/letsencrypt/chain.pem" ] && ([ "${CERTPROVIDER}" == "letsencrypt" ] || [ "${CERTPROVIDER}" == "" ]) && ! openssl x509 -in /config/keys/letsencrypt/chain.pem -noout -issuer | grep -q "ISRG Root X"; then
+if [ -f "/config/keys/letsencrypt/chain.pem" ] && ([ "${CERTPROVIDER}" == "letsencrypt" ] || [ "${CERTPROVIDER}" == "" ]) && [ "${STAGING}" != "true" ] && ! openssl x509 -in /config/keys/letsencrypt/chain.pem -noout -issuer | grep -q "ISRG Root X"; then
     echo "The cert seems to be using the old LE root cert, which is no longer valid. Deleting and revoking."
+    REV_ACMESERVER="https://acme-v02.api.letsencrypt.org/directory"
     certbot revoke --non-interactive --cert-path /config/etc/letsencrypt/live/"$ORIGDOMAIN"/fullchain.pem --server $REV_ACMESERVER
     rm -rf /config/etc/letsencrypt
     mkdir -p /config/etc/letsencrypt


### PR DESCRIPTION
old root cert detection failed when `STAGING` was set to true
revokes failed because ACME_SERVER was only set when the arguments were changed

reported on discord