### PR TITLE
Ipv6 fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -134,6 +134,9 @@ RUN \
   echo "**** remove unnecessary fail2ban filters ****" && \
   rm \
     /etc/fail2ban/jail.d/alpine-ssh.conf && \
+  echo "**** correct ip6tables legacy issue ****" && \
+  rm /sbin/ip6tables && \
+  ln -s /sbin/ip6tables-nft /sbin/ip6tables && \
   echo "**** copy fail2ban default action and filter to /default ****" && \
   mkdir -p /defaults/fail2ban && \
   mv /etc/fail2ban/action.d /defaults/fail2ban/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -135,8 +135,10 @@ RUN \
   rm \
     /etc/fail2ban/jail.d/alpine-ssh.conf && \
   echo "**** correct ip6tables legacy issue ****" && \
-  rm /sbin/ip6tables && \
-  ln -s /sbin/ip6tables-nft /sbin/ip6tables && \
+  rm \ 
+    /sbin/ip6tables && \
+  ln -s \
+    /sbin/ip6tables-nft /sbin/ip6tables && \
   echo "**** copy fail2ban default action and filter to /default ****" && \
   mkdir -p /defaults/fail2ban && \
   mv /etc/fail2ban/action.d /defaults/fail2ban/ && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -134,6 +134,11 @@ RUN \
   echo "**** remove unnecessary fail2ban filters ****" && \
   rm \
     /etc/fail2ban/jail.d/alpine-ssh.conf && \
+  echo "**** correct ip6tables legacy issue ****" && \
+  rm \ 
+    /sbin/ip6tables && \
+  ln -s \
+    /sbin/ip6tables-nft /sbin/ip6tables && \
   echo "**** copy fail2ban default action and filter to /default ****" && \
   mkdir -p /defaults/fail2ban && \
   mv /etc/fail2ban/action.d /defaults/fail2ban/ && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -133,6 +133,11 @@ RUN \
   echo "**** remove unnecessary fail2ban filters ****" && \
   rm \
     /etc/fail2ban/jail.d/alpine-ssh.conf && \
+  echo "**** correct ip6tables legacy issue ****" && \
+  rm \ 
+    /sbin/ip6tables && \
+  ln -s \
+    /sbin/ip6tables-nft /sbin/ip6tables && \
   echo "**** copy fail2ban default action and filter to /default ****" && \
   mkdir -p /defaults/fail2ban && \
   mv /etc/fail2ban/action.d /defaults/fail2ban/ && \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -154,6 +154,7 @@ app_setup_nginx_reverse_proxy_block: ""
 
 # changelog
 changelogs:
+  - { date: "21.12.21:", desc: "Fixed issue with iptables not working as expected" }
   - { date: "30.11.21:", desc: "Move maxmind to a [new mod](https://github.com/linuxserver/docker-mods/tree/swag-maxmind)" }
   - { date: "22.11.21:", desc: "Added support for Infomaniak DNS for certificate generation." }
   - { date: "20.11.21:", desc: "Added support for dnspod validation." }


### PR DESCRIPTION
currently ip6tables inside swag is broken
```
2021-12-21 13:44:54,350 fail2ban.filter         [609]: INFO    [authelia] Found 2607:fb90:ffff:ff11:4ebc:1234:faf:5803 - 2021-12-21 13:44:54
2021-12-21 13:45:00,558 fail2ban.filter         [609]: INFO    [authelia] Found 2607:fb90:ffff:ff11:4ebc:1234:faf:5803 - 2021-12-21 13:45:00
2021-12-21 13:45:04,563 fail2ban.filter         [609]: INFO    [authelia] Found 2607:fb90:ffff:ff11:4ebc:1234:faf:5803 - 2021-12-21 13:45:04
2021-12-21 13:45:04,907 fail2ban.actions        [609]: NOTICE  [authelia] Ban 2607:fb90:ffff:ff11:4ebc:1234:faf:5803
2021-12-21 13:45:04,977 fail2ban.utils          [609]: ERROR   7f69f9f5dd40 -- exec: ip6tables -w -N f2b-authelia
ip6tables -w -A f2b-authelia -j RETURN
ip6tables -w -I INPUT -p tcp -j f2b-authelia
2021-12-21 13:45:04,977 fail2ban.utils          [609]: ERROR   7f69f9f5dd40 -- stderr: "modprobe: can't change directory to '/lib/modules': No such file or directory"
2021-12-21 13:45:04,977 fail2ban.utils          [609]: ERROR   7f69f9f5dd40 -- stderr: "ip6tables v1.8.7 (legacy): can't initialize ip6tables table `filter': Table does not exist (do you need to insmod?)"
2021-12-21 13:45:04,977 fail2ban.utils          [609]: ERROR   7f69f9f5dd40 -- stderr: 'Perhaps ip6tables or your kernel needs to be upgraded.'
2021-12-21 13:45:04,977 fail2ban.utils          [609]: ERROR   7f69f9f5dd40 -- stderr: "modprobe: can't change directory to '/lib/modules': No such file or directory"
2021-12-21 13:45:04,977 fail2ban.utils          [609]: ERROR   7f69f9f5dd40 -- stderr: "ip6tables v1.8.7 (legacy): can't initialize ip6tables table `filter': Table does not exist (do you need to insmod?)"
2021-12-21 13:45:04,977 fail2ban.utils          [609]: ERROR   7f69f9f5dd40 -- stderr: 'Perhaps ip6tables or your kernel needs to be upgraded.'
2021-12-21 13:45:04,977 fail2ban.utils          [609]: ERROR   7f69f9f5dd40 -- stderr: "modprobe: can't change directory to '/lib/modules': No such file or directory"
2021-12-21 13:45:04,977 fail2ban.utils          [609]: ERROR   7f69f9f5dd40 -- stderr: "ip6tables v1.8.7 (legacy): can't initialize ip6tables table `filter': Table does not exist (do you need to insmod?)"
2021-12-21 13:45:04,978 fail2ban.utils          [609]: ERROR   7f69f9f5dd40 -- stderr: 'Perhaps ip6tables or your kernel needs to be upgraded.'
2021-12-21 13:45:04,978 fail2ban.utils          [609]: ERROR   7f69f9f5dd40 -- returned 3
2021-12-21 13:45:04,978 fail2ban.actions        [609]: ERROR   Failed to execute ban jail 'authelia' action 'iptables-allports' info 'ActionInfo({'ip': '2607:fb90:ffff:ff11:4ebc:1234:faf:5803', 'family': 'inet6', 'fid': <function Actions.ActionInfo.<lambda> at 0x7f69f9f938b0>, 'raw-ticket': <function Actions.ActionInfo.<lambda> at 0x7f69f9f93f70>})': Error starting action Jail('authelia')/iptables-allports: 'Script error'
```
however, ip6tables-nft which is also included works fine. this change will remove the legacy ip6tables which needs extra kernel modules that dont exist and replace it with ip6tables-nft which has everything it needs to operate.

After the swap
![image](https://user-images.githubusercontent.com/40674481/146986099-7628d8c1-0112-432c-83b4-31897a1320b2.png)

![image](https://user-images.githubusercontent.com/40674481/146986116-87e664e4-cc91-47b7-a13a-95d1fd762ded.png)

since ip6tables legacy is already broken, there is no risk to making this change. 
