### PR TITLE
replace ip6tables legacy with ip6tables-nft due to missing kernel module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -131,6 +131,11 @@ RUN \
     certbot-plugin-gandi \
     cryptography \
     requests && \
+  echo "**** correct ip6tables legacy issue ****" && \
+  rm \ 
+    /sbin/ip6tables && \
+  ln -s \
+    /sbin/ip6tables-nft /sbin/ip6tables && \
   echo "**** remove unnecessary fail2ban filters ****" && \
   rm \
     /etc/fail2ban/jail.d/alpine-ssh.conf && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -131,6 +131,11 @@ RUN \
     certbot-plugin-gandi \
     cryptography \
     requests && \
+  echo "**** correct ip6tables legacy issue ****" && \
+  rm \ 
+    /sbin/ip6tables && \
+  ln -s \
+    /sbin/ip6tables-nft /sbin/ip6tables && \
   echo "**** remove unnecessary fail2ban filters ****" && \
   rm \
     /etc/fail2ban/jail.d/alpine-ssh.conf && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -130,6 +130,11 @@ RUN \
     certbot-plugin-gandi \
     cryptography \
     requests && \
+  echo "**** correct ip6tables legacy issue ****" && \
+  rm \ 
+    /sbin/ip6tables && \
+  ln -s \
+    /sbin/ip6tables-nft /sbin/ip6tables && \
   echo "**** remove unnecessary fail2ban filters ****" && \
   rm \
     /etc/fail2ban/jail.d/alpine-ssh.conf && \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -118,12 +118,11 @@ pipeline {
             script: '''echo ${EXT_RELEASE} | sed 's/[~,%@+;:/]//g' ''',
             returnStdout: true).trim()
 
-          env.SEMVER = (new Date()).format('YYYY.MM.dd')
-          def semver = env.EXT_RELEASE_CLEAN =~ /(\d+)\.(\d+)\.(\d+)$/
+          def semver = env.EXT_RELEASE_CLEAN =~ /(\d+)\.(\d+)\.(\d+)/
           if (semver.find()) {
             env.SEMVER = "${semver[0][1]}.${semver[0][2]}.${semver[0][3]}"
           } else {
-            semver = env.EXT_RELEASE_CLEAN =~ /(\d+)\.(\d+)(?:\.(\d+))?(.*)$/
+            semver = env.EXT_RELEASE_CLEAN =~ /(\d+)\.(\d+)(?:\.(\d+))?(.*)/
             if (semver.find()) {
               if (semver[0][3]) {
                 env.SEMVER = "${semver[0][1]}.${semver[0][2]}.${semver[0][3]}"
@@ -133,7 +132,15 @@ pipeline {
             }
           }
 
-          println("SEMVER: ${env.SEMVER}")
+          if (env.SEMVER != null) {
+            if (BRANCH_NAME != "master" && BRANCH_NAME != "main") {
+              env.SEMVER = "${env.SEMVER}-${BRANCH_NAME}"
+            }
+            println("SEMVER: ${env.SEMVER}")
+          } else {
+            println("No SEMVER detected")
+          }
+
         }
       }
     }
@@ -402,10 +409,10 @@ pipeline {
       steps{
         sh '''#! /bin/bash
               set -e
-              PACKAGE_UUID=$(curl -X GET -H "Authorization: Bearer ${SCARF_TOKEN}" https://scarf.sh/api/v1/packages | jq -r '.[] | select(.name=="linuxserver/swag") | .uuid')
+              PACKAGE_UUID=$(curl -X GET -H "Authorization: Bearer ${SCARF_TOKEN}" https://scarf.sh/api/v1/organizations/linuxserver-ci/packages | jq -r '.[] | select(.name=="linuxserver/swag") | .uuid')
               if [ -z "${PACKAGE_UUID}" ]; then
                 echo "Adding package to Scarf.sh"
-                PACKAGE_UUID=$(curl -sX POST https://scarf.sh/api/v1/packages \
+                curl -sX POST https://scarf.sh/api/v1/organizations/linuxserver-ci/packages \
                   -H "Authorization: Bearer ${SCARF_TOKEN}" \
                   -H "Content-Type: application/json" \
                   -d '{"name":"linuxserver/swag",\
@@ -413,22 +420,10 @@ pipeline {
                        "libraryType":"docker",\
                        "website":"https://github.com/linuxserver/docker-swag",\
                        "backendUrl":"https://ghcr.io/linuxserver/swag",\
-                       "publicUrl":"https://lscr.io/linuxserver/swag"}' \
-                  | jq -r .uuid)
+                       "publicUrl":"https://lscr.io/linuxserver/swag"}' || :
               else
                 echo "Package already exists on Scarf.sh"
               fi
-              echo "Setting permissions on Scarf.sh for package ${PACKAGE_UUID}"
-              curl -X POST https://scarf.sh/api/v1/packages/${PACKAGE_UUID}/permissions \
-                -H "Authorization: Bearer ${SCARF_TOKEN}" \
-                -H "Content-Type: application/json" \
-                -d '[{"userQuery":"Spad","permissionLevel":"admin"},\
-                     {"userQuery":"roxedus","permissionLevel":"admin"},\
-                     {"userQuery":"nemchik","permissionLevel":"admin"},\
-                     {"userQuery":"driz","permissionLevel":"admin"},\
-                     {"userQuery":"aptalca","permissionLevel":"admin"},\
-                     {"userQuery":"saarg","permissionLevel":"admin"},\
-                     {"userQuery":"Stark","permissionLevel":"admin"}]'
            '''
       } 
     }
@@ -752,11 +747,15 @@ pipeline {
                     docker tag ${IMAGE}:${META_TAG} ${PUSHIMAGE}:${META_TAG}
                     docker tag ${PUSHIMAGE}:${META_TAG} ${PUSHIMAGE}:latest
                     docker tag ${PUSHIMAGE}:${META_TAG} ${PUSHIMAGE}:${EXT_RELEASE_TAG}
-                    docker tag ${PUSHIMAGE}:${META_TAG} ${PUSHIMAGE}:${SEMVER}
+                    if [ -n "${SEMVER}" ]; then
+                      docker tag ${PUSHIMAGE}:${META_TAG} ${PUSHIMAGE}:${SEMVER}
+                    fi
                     docker push ${PUSHIMAGE}:latest
                     docker push ${PUSHIMAGE}:${META_TAG}
                     docker push ${PUSHIMAGE}:${EXT_RELEASE_TAG}
-                    docker push ${PUSHIMAGE}:${SEMVER}
+                    if [ -n "${SEMVER}" ]; then
+                     docker push ${PUSHIMAGE}:${SEMVER}
+                    fi
                   done
                '''
           }
@@ -765,8 +764,10 @@ pipeline {
                   docker rmi \
                   ${DELETEIMAGE}:${META_TAG} \
                   ${DELETEIMAGE}:${EXT_RELEASE_TAG} \
-                  ${DELETEIMAGE}:latest \
-                  ${DELETEIMAGE}:${SEMVER} || :
+                  ${DELETEIMAGE}:latest || :
+                  if [ -n "${SEMVER}" ]; then
+                    docker rmi ${DELETEIMAGE}:${SEMVER} || :
+                  fi
                 done
              '''
         }
@@ -816,9 +817,11 @@ pipeline {
                     docker tag ${MANIFESTIMAGE}:amd64-${META_TAG} ${MANIFESTIMAGE}:amd64-${EXT_RELEASE_TAG}
                     docker tag ${MANIFESTIMAGE}:arm32v7-${META_TAG} ${MANIFESTIMAGE}:arm32v7-${EXT_RELEASE_TAG}
                     docker tag ${MANIFESTIMAGE}:arm64v8-${META_TAG} ${MANIFESTIMAGE}:arm64v8-${EXT_RELEASE_TAG}
-                    docker tag ${MANIFESTIMAGE}:amd64-${META_TAG} ${MANIFESTIMAGE}:amd64-${SEMVER}
-                    docker tag ${MANIFESTIMAGE}:arm32v7-${META_TAG} ${MANIFESTIMAGE}:arm32v7-${SEMVER}
-                    docker tag ${MANIFESTIMAGE}:arm64v8-${META_TAG} ${MANIFESTIMAGE}:arm64v8-${SEMVER}
+                    if [ -n "${SEMVER}" ]; then
+                      docker tag ${MANIFESTIMAGE}:amd64-${META_TAG} ${MANIFESTIMAGE}:amd64-${SEMVER}
+                      docker tag ${MANIFESTIMAGE}:arm32v7-${META_TAG} ${MANIFESTIMAGE}:arm32v7-${SEMVER}
+                      docker tag ${MANIFESTIMAGE}:arm64v8-${META_TAG} ${MANIFESTIMAGE}:arm64v8-${SEMVER}
+                    fi
                     docker push ${MANIFESTIMAGE}:amd64-${META_TAG}
                     docker push ${MANIFESTIMAGE}:arm32v7-${META_TAG}
                     docker push ${MANIFESTIMAGE}:arm64v8-${META_TAG}
@@ -828,9 +831,11 @@ pipeline {
                     docker push ${MANIFESTIMAGE}:amd64-${EXT_RELEASE_TAG}
                     docker push ${MANIFESTIMAGE}:arm32v7-${EXT_RELEASE_TAG}
                     docker push ${MANIFESTIMAGE}:arm64v8-${EXT_RELEASE_TAG}
-                    docker push ${MANIFESTIMAGE}:amd64-${SEMVER}
-                    docker push ${MANIFESTIMAGE}:arm32v7-${SEMVER}
-                    docker push ${MANIFESTIMAGE}:arm64v8-${SEMVER}
+                    if [ -n "${SEMVER}" ]; then
+                      docker push ${MANIFESTIMAGE}:amd64-${SEMVER}
+                      docker push ${MANIFESTIMAGE}:arm32v7-${SEMVER}
+                      docker push ${MANIFESTIMAGE}:arm64v8-${SEMVER}
+                    fi
                     docker manifest push --purge ${MANIFESTIMAGE}:latest || :
                     docker manifest create ${MANIFESTIMAGE}:latest ${MANIFESTIMAGE}:amd64-latest ${MANIFESTIMAGE}:arm32v7-latest ${MANIFESTIMAGE}:arm64v8-latest
                     docker manifest annotate ${MANIFESTIMAGE}:latest ${MANIFESTIMAGE}:arm32v7-latest --os linux --arch arm
@@ -843,14 +848,18 @@ pipeline {
                     docker manifest create ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} ${MANIFESTIMAGE}:amd64-${EXT_RELEASE_TAG} ${MANIFESTIMAGE}:arm32v7-${EXT_RELEASE_TAG} ${MANIFESTIMAGE}:arm64v8-${EXT_RELEASE_TAG}
                     docker manifest annotate ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} ${MANIFESTIMAGE}:arm32v7-${EXT_RELEASE_TAG} --os linux --arch arm
                     docker manifest annotate ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} ${MANIFESTIMAGE}:arm64v8-${EXT_RELEASE_TAG} --os linux --arch arm64 --variant v8
-                    docker manifest push --purge ${MANIFESTIMAGE}:${SEMVER} || :
-                    docker manifest create ${MANIFESTIMAGE}:${SEMVER} ${MANIFESTIMAGE}:amd64-${SEMVER} ${MANIFESTIMAGE}:arm32v7-${SEMVER} ${MANIFESTIMAGE}:arm64v8-${SEMVER}
-                    docker manifest annotate ${MANIFESTIMAGE}:${SEMVER} ${MANIFESTIMAGE}:arm32v7-${SEMVER} --os linux --arch arm
-                    docker manifest annotate ${MANIFESTIMAGE}:${SEMVER} ${MANIFESTIMAGE}:arm64v8-${SEMVER} --os linux --arch arm64 --variant v8
+                    if [ -n "${SEMVER}" ]; then
+                      docker manifest push --purge ${MANIFESTIMAGE}:${SEMVER} || :
+                      docker manifest create ${MANIFESTIMAGE}:${SEMVER} ${MANIFESTIMAGE}:amd64-${SEMVER} ${MANIFESTIMAGE}:arm32v7-${SEMVER} ${MANIFESTIMAGE}:arm64v8-${SEMVER}
+                      docker manifest annotate ${MANIFESTIMAGE}:${SEMVER} ${MANIFESTIMAGE}:arm32v7-${SEMVER} --os linux --arch arm
+                      docker manifest annotate ${MANIFESTIMAGE}:${SEMVER} ${MANIFESTIMAGE}:arm64v8-${SEMVER} --os linux --arch arm64 --variant v8
+                    fi
                     docker manifest push --purge ${MANIFESTIMAGE}:latest
                     docker manifest push --purge ${MANIFESTIMAGE}:${META_TAG} 
                     docker manifest push --purge ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} 
-                    docker manifest push --purge ${MANIFESTIMAGE}:${SEMVER} 
+                    if [ -n "${SEMVER}" ]; then
+                      docker manifest push --purge ${MANIFESTIMAGE}:${SEMVER} 
+                    fi
                   done
                '''
           }
@@ -860,15 +869,18 @@ pipeline {
                   ${DELETEIMAGE}:amd64-${META_TAG} \
                   ${DELETEIMAGE}:amd64-latest \
                   ${DELETEIMAGE}:amd64-${EXT_RELEASE_TAG} \
-                  ${DELETEIMAGE}:amd64-${SEMVER} \
                   ${DELETEIMAGE}:arm32v7-${META_TAG} \
                   ${DELETEIMAGE}:arm32v7-latest \
                   ${DELETEIMAGE}:arm32v7-${EXT_RELEASE_TAG} \
-                  ${DELETEIMAGE}:arm32v7-${SEMVER} \
                   ${DELETEIMAGE}:arm64v8-${META_TAG} \
                   ${DELETEIMAGE}:arm64v8-latest \
-                  ${DELETEIMAGE}:arm64v8-${EXT_RELEASE_TAG} \
-                  ${DELETEIMAGE}:arm64v8-${SEMVER} || :
+                  ${DELETEIMAGE}:arm64v8-${EXT_RELEASE_TAG} || :
+                  if [ -n "${SEMVER}" ]; then
+                    docker rmi \
+                    ${DELETEIMAGE}:amd64-${SEMVER} \
+                    ${DELETEIMAGE}:arm32v7-${SEMVER} \
+                    ${DELETEIMAGE}:arm64v8-${SEMVER} || :
+                  fi
                 done
                 docker rmi \
                 ghcr.io/linuxserver/lsiodev-buildcache:arm32v7-${COMMIT_SHA}-${BUILD_NUMBER} \

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Find us at:
 
 # [linuxserver/swag](https://github.com/linuxserver/docker-swag)
 
+[![Scarf.io pulls](https://scarf.sh/installs-badge/linuxserver-ci/linuxserver%2Fswag?color=94398d&label-color=555555&logo-color=ffffff&style=for-the-badge&package-type=docker)](https://scarf.sh/gateway/linuxserver-ci/docker/linuxserver%2Fswag)
 [![GitHub Stars](https://img.shields.io/github/stars/linuxserver/docker-swag.svg?color=94398d&labelColor=555555&logoColor=ffffff&style=for-the-badge&logo=github)](https://github.com/linuxserver/docker-swag)
 [![GitHub Release](https://img.shields.io/github/release/linuxserver/docker-swag.svg?color=94398d&labelColor=555555&logoColor=ffffff&style=for-the-badge&logo=github)](https://github.com/linuxserver/docker-swag/releases)
 [![GitHub Package Repository](https://img.shields.io/static/v1.svg?color=94398d&labelColor=555555&logoColor=ffffff&style=for-the-badge&label=linuxserver.io&message=GitHub%20Package&logo=github)](https://github.com/linuxserver/docker-swag/packages)
@@ -329,6 +330,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **21.12.21:** - Fixed issue with iptables not working as expected
 * **30.11.21:** - Move maxmind to a [new mod](https://github.com/linuxserver/docker-mods/tree/swag-maxmind)
 * **22.11.21:** - Added support for Infomaniak DNS for certificate generation.
 * **20.11.21:** - Added support for dnspod validation.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -154,6 +154,7 @@ app_setup_nginx_reverse_proxy_block: ""
 
 # changelog
 changelogs:
+  - { date: "21.12.21:", desc: "Fixed issue with iptables not working as expected" }
   - { date: "30.11.21:", desc: "Move maxmind to a [new mod](https://github.com/linuxserver/docker-mods/tree/swag-maxmind)" }
   - { date: "22.11.21:", desc: "Added support for Infomaniak DNS for certificate generation." }
   - { date: "20.11.21:", desc: "Added support for dnspod validation." }


### PR DESCRIPTION
currently ip6tables legacy requires a missing kernel module, however ip6tables-nft is already included in the image and works as expected.

**Prior to making the change**
```
2021-12-21 13:44:54,350 fail2ban.filter         [609]: INFO    [authelia] Found 2607:fb90:ffff:ff11:4ebc:1234:faf:5803 - 2021-12-21 13:44:54
2021-12-21 13:45:00,558 fail2ban.filter         [609]: INFO    [authelia] Found 2607:fb90:ffff:ff11:4ebc:1234:faf:5803 - 2021-12-21 13:45:00
2021-12-21 13:45:04,563 fail2ban.filter         [609]: INFO    [authelia] Found 2607:fb90:ffff:ff11:4ebc:1234:faf:5803 - 2021-12-21 13:45:04
2021-12-21 13:45:04,907 fail2ban.actions        [609]: NOTICE  [authelia] Ban 2607:fb90:ffff:ff11:4ebc:1234:faf:5803
2021-12-21 13:45:04,977 fail2ban.utils          [609]: ERROR   7f69f9f5dd40 -- exec: ip6tables -w -N f2b-authelia
ip6tables -w -A f2b-authelia -j RETURN
ip6tables -w -I INPUT -p tcp -j f2b-authelia
2021-12-21 13:45:04,977 fail2ban.utils          [609]: ERROR   7f69f9f5dd40 -- stderr: "modprobe: can't change directory to '/lib/modules': No such file or directory"
2021-12-21 13:45:04,977 fail2ban.utils          [609]: ERROR   7f69f9f5dd40 -- stderr: "ip6tables v1.8.7 (legacy): can't initialize ip6tables table `filter': Table does not exist (do you need to insmod?)"
2021-12-21 13:45:04,977 fail2ban.utils          [609]: ERROR   7f69f9f5dd40 -- stderr: 'Perhaps ip6tables or your kernel needs to be upgraded.'
2021-12-21 13:45:04,977 fail2ban.utils          [609]: ERROR   7f69f9f5dd40 -- stderr: "modprobe: can't change directory to '/lib/modules': No such file or directory"
2021-12-21 13:45:04,977 fail2ban.utils          [609]: ERROR   7f69f9f5dd40 -- stderr: "ip6tables v1.8.7 (legacy): can't initialize ip6tables table `filter': Table does not exist (do you need to insmod?)"
2021-12-21 13:45:04,977 fail2ban.utils          [609]: ERROR   7f69f9f5dd40 -- stderr: 'Perhaps ip6tables or your kernel needs to be upgraded.'
2021-12-21 13:45:04,977 fail2ban.utils          [609]: ERROR   7f69f9f5dd40 -- stderr: "modprobe: can't change directory to '/lib/modules': No such file or directory"
2021-12-21 13:45:04,977 fail2ban.utils          [609]: ERROR   7f69f9f5dd40 -- stderr: "ip6tables v1.8.7 (legacy): can't initialize ip6tables table `filter': Table does not exist (do you need to insmod?)"
2021-12-21 13:45:04,978 fail2ban.utils          [609]: ERROR   7f69f9f5dd40 -- stderr: 'Perhaps ip6tables or your kernel needs to be upgraded.'
2021-12-21 13:45:04,978 fail2ban.utils          [609]: ERROR   7f69f9f5dd40 -- returned 3
2021-12-21 13:45:04,978 fail2ban.actions        [609]: ERROR   Failed to execute ban jail 'authelia' action 'iptables-allports' info 'ActionInfo({'ip': '2607:fb90:ffff:ff11:4ebc:1234:faf:5803', 'family': 'inet6', 'fid': <function Actions.ActionInfo.<lambda> at 0x7f69f9f938b0>, 'raw-ticket': <function Actions.ActionInfo.<lambda> at 0x7f69f9f93f70>})': Error starting action Jail('authelia')/iptables-allports: 'Script error'
```

**After making the change**

![image](https://user-images.githubusercontent.com/40674481/146988367-574d93cf-26fb-4368-b9fe-38c3ae4eb275.png)

![image](https://user-images.githubusercontent.com/40674481/146988374-c7fd442d-0663-45c3-93a6-a665af569aab.png)

As ip6tables is currently non-functional and we do not support ipv6 at all, this is a non-breaking change with 0 risk. 