### PR TITLE
Added a fail2ban jail for nginx unauthorized

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **09.01.22:** - Added a fail2ban jail for nginx unauthorized
 * **21.12.21:** - Fixed issue with iptables not working as expected
 * **30.11.21:** - Move maxmind to a [new mod](https://github.com/linuxserver/docker-mods/tree/swag-maxmind)
 * **22.11.21:** - Added support for Infomaniak DNS for certificate generation.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -154,6 +154,7 @@ app_setup_nginx_reverse_proxy_block: ""
 
 # changelog
 changelogs:
+  - { date: "09.01.22:", desc: "Added a fail2ban jail for nginx unauthorized" }
   - { date: "21.12.21:", desc: "Fixed issue with iptables not working as expected" }
   - { date: "30.11.21:", desc: "Move maxmind to a [new mod](https://github.com/linuxserver/docker-mods/tree/swag-maxmind)" }
   - { date: "22.11.21:", desc: "Added support for Infomaniak DNS for certificate generation." }

--- a/root/defaults/fail2ban/filter.d/nginx-unauthorized.conf
+++ b/root/defaults/fail2ban/filter.d/nginx-unauthorized.conf
@@ -1,0 +1,7 @@
+# A fail2ban filter for unauthorized log messages
+
+[Definition]
+
+failregex = ^<HOST>.*"(GET|POST|HEAD).*" 401 .*$
+
+ignoreregex = 

--- a/root/defaults/jail.local
+++ b/root/defaults/jail.local
@@ -1,10 +1,14 @@
-## Version 2020/05/10 - Changelog: https://github.com/linuxserver/docker-swag/commits/master/root/defaults/jail.local
+## Version 2022/01/09 - Changelog: https://github.com/linuxserver/docker-swag/commits/master/root/defaults/jail.local
 # This is the custom version of the jail.conf for fail2ban
 # Feel free to modify this and add additional filters
 # Then you can drop the new filter conf files into the fail2ban-filters
 # folder and restart the container
 
 [DEFAULT]
+# Prevents banning LAN subnets
+ignoreip = 10.0.0.0/8
+           192.168.0.0/16
+           172.16.0.0/12
 
 # Changes the default ban action from "iptables-multiport", which causes issues on some platforms, to "iptables-allports".
 banaction = iptables-allports
@@ -21,37 +25,35 @@ maxretry = 5
 
 
 [ssh]
-
 enabled = false
 
-
 [nginx-http-auth]
-
 enabled  = true
 filter   = nginx-http-auth
 port     = http,https
 logpath  = /config/log/nginx/error.log
 
-
 [nginx-badbots]
-
 enabled  = true
 port     = http,https
 filter   = nginx-badbots
 logpath  = /config/log/nginx/access.log
 maxretry = 2
 
-
 [nginx-botsearch]
-
 enabled  = true
 port     = http,https
 filter   = nginx-botsearch
 logpath  = /config/log/nginx/access.log
 
 [nginx-deny]
-
 enabled  = true
 port     = http,https
 filter   = nginx-deny
 logpath  = /config/log/nginx/error.log
+
+[nginx-unauthorized]
+enabled  = true
+port     = http,https
+filter   = nginx-unauthorized
+logpath  = /config/log/nginx/unauthorized.log

--- a/root/defaults/nginx.conf
+++ b/root/defaults/nginx.conf
@@ -1,4 +1,4 @@
-## Version 2021/04/27 - Changelog: https://github.com/linuxserver/docker-swag/commits/master/root/defaults/nginx.conf
+## Version 2022/01/09 - Changelog: https://github.com/linuxserver/docker-swag/commits/master/root/defaults/nginx.conf
 
 user abc;
 
@@ -55,6 +55,13 @@ http {
         '' close;
     }
 
+    # Saves unauthorized log messages to a separate log file
+    map $status $unauthorized {
+        default 0;
+        ~^401  1;
+    }
+    access_log /config/log/nginx/unauthorized.log combined if=$unauthorized;
+    
     # Sets the path, format, and configuration for a buffered log write.
     access_log /config/log/nginx/access.log;
 


### PR DESCRIPTION
- Added a fail2ban jail for nginx unauthorized
- Ignore local subnets in fail2ban to avoid banning the user

Example log message:
`1.2.3.4 - - [09/Jan/2022:17:20:48 +0200] "POST /Users/authenticatebyname HTTP/1.1" 401 36 "-" "Mozilla/5.0 (Android 10; Mobile; rv:91.0) Gecko/91.0 Firefox/91.0"`

```
Status for the jail: nginx-unauthorized
|- Filter
|  |- Currently failed: 1
|  |- Total failed:     1
|  `- File list:        /config/log/nginx/unauthorized.log
```