### PR TITLE
authelia-server.conf: allow pipe character in URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **16.02.22:** - [Existing users should update:](https://github.com/linuxserver/docker-swag/blob/master/README.md#updating-configs) authelia-server.conf - Allow pipe character in request URI
 * **09.01.22:** - Added a fail2ban jail for nginx unauthorized
 * **21.12.21:** - Fixed issue with iptables not working as expected
 * **30.11.21:** - Move maxmind to a [new mod](https://github.com/linuxserver/docker-mods/tree/swag-maxmind)

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -154,6 +154,7 @@ app_setup_nginx_reverse_proxy_block: ""
 
 # changelog
 changelogs:
+  - { date: "16.02.22:", desc: "[Existing users should update:](https://github.com/linuxserver/docker-swag/blob/master/README.md#updating-configs) authelia-server.conf - Allow pipe character in request URI" }
   - { date: "09.01.22:", desc: "Added a fail2ban jail for nginx unauthorized" }
   - { date: "21.12.21:", desc: "Fixed issue with iptables not working as expected" }
   - { date: "30.11.21:", desc: "Move maxmind to a [new mod](https://github.com/linuxserver/docker-mods/tree/swag-maxmind)" }

--- a/root/defaults/authelia-server.conf
+++ b/root/defaults/authelia-server.conf
@@ -1,4 +1,4 @@
-## Version 2021/05/28 - Changelog: https://github.com/linuxserver/docker-swag/commits/master/root/defaults/authelia-server.conf
+## Version 2022/02/16 - Changelog: https://github.com/linuxserver/docker-swag/commits/master/root/defaults/authelia-server.conf
 # Make sure that your authelia container is in the same user defined bridge network and is named authelia
 
 location ^~ /authelia {
@@ -10,7 +10,7 @@ location ^~ /authelia {
 
 location = /authelia/api/verify {
     internal;
-    if ($request_uri ~ [^a-zA-Z0-9_+-=\!@$%&*?~.:#'\;\(\)\[\]]) {
+    if ($request_uri ~ [^a-zA-Z0-9_+-=|\!@$%&*?~.:#'\;\(\)\[\]]) {
         return 401;
     }
     include /config/nginx/resolver.conf;


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-swag/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:
The characters in the regex used for mitigating CVE-2021-32637 are not exhaustive since query strings seem to not always conform to the RFC3986, this is also mentioned in the [security advisory](https://github.com/authelia/authelia/security/advisories/GHSA-68wm-pfjf-wqp6) for the CVE.

For example, attempting to delete multiple torrents in the qBittorrent WebUI results in an URL like the following:

    confirmdeletion.html?hashes=HASH1|HASH2

This URL is valid and parsable by Authelia, but due to the regex it gets redirected infinitely.

To fix this, also allow pipe characters in the request URI.

<!--- Describe your changes in detail -->

## Benefits of this PR and context:
The regex was introduced in 224abb686dddae292c739b69f8ae97fabb2db0fb to work around a CVE. The security advisory notes that the regex is not exhaustive, and there are projects (such as qbittorrent) that use pipe characters in URIs, which are valid and parsable by Authelia.

## How Has This Been Tested?
After the regex modification, URLs with pipe characters in them are no longer redirected to the auth endpoint.

## Source / References:
Original PR: https://github.com/linuxserver/docker-swag/pull/130
CVE: http://cve.mitre.org/cgi-bin/cvename.cgi?name=2021-32637