### PR TITLE
fix: permit authelia login when using auth_request

### DIFF
--- a/root/defaults/authelia-server.conf
+++ b/root/defaults/authelia-server.conf
@@ -2,6 +2,7 @@
 # Make sure that your authelia container is in the same user defined bridge network and is named authelia
 
 location ^~ /authelia {
+    auth_request off;
     include /config/nginx/proxy.conf;
     include /config/nginx/resolver.conf;
     set $upstream_authelia authelia;


### PR DESCRIPTION
 - [x] I have read the [contributing](https://github.com/linuxserver/docker-swag/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:

When using proxy auth via Authelia (e.g. setting up `auth_request` for Organizr as described in `organizr-auth.subfolder.conf.sample`), the Authelia login URL (`/authelia`) actually requires authentication by the application (this may only apply to subdomain apps, I don't use subfolder apps so haven't tested) resulting in a 401 error instead of the login page, because you're not currently logged in (catch-22). This turns off that authentication for the Authelia login URL only, permitting login.

## Benefits of this PR and context:

Fixes unexpected behaviour where you cannot login to Authelia if you're not logged into Authelia. I discovered this when setting up proxy auth via Authelia for my Organizr container following the instructions in the `organizr-auth.subfolder.conf.sample` file. For anyone not using `auth_request` this is essentially a noop. For anyone using `auth_request`, this permits access to the Authelia login URL instead of that URL returning a 401 error. This issue may only apply to subdomain proxies as I haven't tested subfolder proxies.

## How Has This Been Tested?
Tested by editing the config directly in my existing setup and reloading the container.

## Source / References:

http://nginx.org/en/docs/http/ngx_http_auth_request_module.html#auth_request
