### PR TITLE
fix: missing chars in authelia server 401

### DIFF
--- a/root/defaults/authelia-server.conf
+++ b/root/defaults/authelia-server.conf
@@ -10,7 +10,7 @@ location ^~ /authelia {
 
 location = /authelia/api/verify {
     internal;
-    if ($request_uri ~ [^a-zA-Z0-9_+-=\!@$%&*?~.:#'\;\(\)\[\]]) {
+    if ($request_uri ~ [^a-zA-Z0-9_+-=\!@$%&*?~.:#'\;\(\)\[\]])\{\} {
         return 401;
     }
     include /config/nginx/resolver.conf;

--- a/root/defaults/authelia-server.conf
+++ b/root/defaults/authelia-server.conf
@@ -10,7 +10,7 @@ location ^~ /authelia {
 
 location = /authelia/api/verify {
     internal;
-    if ($request_uri ~ [^a-zA-Z0-9_+-=\!@$%&*?~.:#'\;\(\)\[\]])\{\} {
+    if ($request_uri ~ [^a-zA-Z0-9_+-=\!@$%&*?~.:#'\;\(\)\[\]\{\}]) {
         return 401;
     }
     include /config/nginx/resolver.conf;

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -109,7 +109,7 @@ fi
 
 # patch authelia-server.conf for CVE-2021-32637
 if ! grep -q 'if ($request_uri ~' /config/nginx/authelia-server.conf; then
-    sed -i '/internal;/a \ \ \ \ if ($request_uri ~ [^a-zA-Z0-9_+-=\\!@$%&*?~.:#'\''\\;\\(\\)\\[\\]]) { return 401; }' /config/nginx/authelia-server.conf
+    sed -i '/internal;/a \ \ \ \ if ($request_uri ~ [^a-zA-Z0-9_+-=\\!@$%&*?~.:#'\''\\;\\(\\)\\[\\]])\\{\\} { return 401; }' /config/nginx/authelia-server.conf
 fi
 
 # copy pre-generated dhparams or generate if needed

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -109,7 +109,7 @@ fi
 
 # patch authelia-server.conf for CVE-2021-32637
 if ! grep -q 'if ($request_uri ~' /config/nginx/authelia-server.conf; then
-    sed -i '/internal;/a \ \ \ \ if ($request_uri ~ [^a-zA-Z0-9_+-=\\!@$%&*?~.:#'\''\\;\\(\\)\\[\\]])\\{\\} { return 401; }' /config/nginx/authelia-server.conf
+    sed -i '/internal;/a \ \ \ \ if ($request_uri ~ [^a-zA-Z0-9_+-=\\!@$%&*?~.:#'\''\\;\\(\\)\\[\\]\\{\\}]) { return 401; }' /config/nginx/authelia-server.conf
 fi
 
 # copy pre-generated dhparams or generate if needed


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-swag/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
This is NOT a security fix. The following addresses a problem with Synology which uses a non-standard char in the DSM application `{}`. This alleviates this issue. I don't believe it needs to be fixed in existing configs but I'll leave that up to you.

I think another option would be removing this check entirely as the version affected in the original CVE is over a year old at this point. Let me know what you think. I have not expressly checked the change to `50-config` but I suspect that'll be picked up in CI. 

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
