### PR TITLE
Changed default certificate from RSA to ECC

### DIFF
--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -340,7 +340,7 @@ if [ ! -f "/config/keys/letsencrypt/fullchain.pem" ]; then
     fi
     echo "Generating new certificate"
     # shellcheck disable=SC2086
-    certbot certonly --renew-by-default --server $ACMESERVER $ZEROSSL_EAB $PREFCHAL --rsa-key-size 4096 $EMAILPARAM --agree-tos $URL_REAL
+    certbot certonly --renew-by-default --server $ACMESERVER $ZEROSSL_EAB $PREFCHAL --elliptic-curve secp384r1 --key-type ecdsa $EMAILPARAM --agree-tos $URL_REAL
     if [ -d /config/keys/letsencrypt ]; then
         cd /config/keys/letsencrypt || exit
     else


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
closes #232 
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-swag/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
I have changed the default certificate type to 384Bit ECC instead of 4096Bit RSA. This is considered more secure and will also result in a 100% score on ssllabs:
![image](https://user-images.githubusercontent.com/70581801/169229098-3477aa13-5516-45ef-8c71-486036e852dc.png)
This change works because recent versions of certbot support ecdsa certificates.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
This will close https://github.com/linuxserver/docker-swag/issues/232

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have tested building the docker container on an arm64 server. As I haven't changed any dockerfile this should be enough. 
I have tested obtaining a certificate which works fine and I have verified that changes are working.

Before merging we should discuss whether to make this the default option as it is right now or whether to add an additional environment flag for obtaining an ecdsa certificate.  I also don't know yet what happens when the container tries to renew an existing RSA certificate as I can't test this. 
