### PR TITLE
Added acmedns validation plugin for certbot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,6 +102,7 @@ RUN \
     pip wheel && \
   pip install -U --find-links https://wheel-index.linuxserver.io/alpine-3.15/ \
     ${CERTBOT} \
+    certbot-dns-acmedns \
     certbot-dns-aliyun \
     certbot-dns-azure \
     certbot-dns-cloudflare \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -102,6 +102,7 @@ RUN \
     pip wheel && \
   pip install -U --find-links https://wheel-index.linuxserver.io/alpine-3.15/ \
     ${CERTBOT} \
+    certbot-dns-acmedns \
     certbot-dns-aliyun \
     certbot-dns-azure \
     certbot-dns-cloudflare \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -102,6 +102,7 @@ RUN \
     pip wheel && \
   pip install -U --find-links https://wheel-index.linuxserver.io/alpine-3.15/ \
     ${CERTBOT} \
+    certbot-dns-acmedns \
     certbot-dns-aliyun \
     certbot-dns-azure \
     certbot-dns-cloudflare \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -51,7 +51,7 @@ opt_param_usage_include_env: true
 opt_param_env_vars:
   - { env_var: "SUBDOMAINS", env_value: "www,", desc: "Subdomains you'd like the cert to cover (comma separated, no spaces) ie. `www,ftp,cloud`. For a wildcard cert, set this _exactly_ to `wildcard` (wildcard cert is available via `dns` and `duckdns` validation only)" }
   - { env_var: "CERTPROVIDER", env_value: "", desc: "Optionally define the cert provider. Set to `zerossl` for ZeroSSL certs (requires existing [ZeroSSL account](https://app.zerossl.com/signup) and the e-mail address entered in `EMAIL` env var). Otherwise defaults to Let's Encrypt." }
-  - { env_var: "DNSPLUGIN", env_value: "cloudflare", desc: "Required if `VALIDATION` is set to `dns`. Options are `aliyun`, `azure`, `cloudflare`, `cloudxns`, `cpanel`, `desec`, `digitalocean`, `directadmin`, `dnsimple`, `dnsmadeeasy`, `dnspod`, `domeneshop`, `dynu`, `gandi`, `gehirn`, `google`, `he`, `hetzner`, `infomaniak`, `inwx`, `ionos`, `linode`, `loopia`, `luadns`, `netcup`, `njalla`, `nsone`, `ovh`, `rfc2136`, `route53`, `sakuracloud`, `standalone`, `transip` and `vultr`. Also need to enter the credentials into the corresponding ini (or json for some plugins) file under `/config/dns-conf`." }
+  - { env_var: "DNSPLUGIN", env_value: "cloudflare", desc: "Required if `VALIDATION` is set to `dns`. Options are `acmedns`,`aliyun`, `azure`, `cloudflare`, `cloudxns`, `cpanel`, `desec`, `digitalocean`, `directadmin`, `dnsimple`, `dnsmadeeasy`, `dnspod`, `domeneshop`, `dynu`, `gandi`, `gehirn`, `google`, `he`, `hetzner`, `infomaniak`, `inwx`, `ionos`, `linode`, `loopia`, `luadns`, `netcup`, `njalla`, `nsone`, `ovh`, `rfc2136`, `route53`, `sakuracloud`, `standalone`, `transip` and `vultr`. Also need to enter the credentials into the corresponding ini (or json for some plugins) file under `/config/dns-conf`." }
   - { env_var: "PROPAGATION", env_value: "", desc: "Optionally override (in seconds) the default propagation time for the dns plugins." }
   - { env_var: "DUCKDNSTOKEN", env_value: "", desc: "Required if `VALIDATION` is set to `duckdns`. Retrieve your token from https://www.duckdns.org" }
   - { env_var: "EMAIL", env_value: "", desc: "Optional e-mail address used for cert expiration notifications (Required for ZeroSSL)." }
@@ -155,6 +155,7 @@ app_setup_nginx_reverse_proxy_block: ""
 
 # changelog
 changelogs:
+  - { date: "22.09.22:", desc: "Added certbot-dns-acmedns for DNS01 validation." }
   - { date: "20.08.22:", desc: "[Existing users should update:](https://github.com/linuxserver/docker-swag/blob/master/README.md#updating-configs) nginx.conf - Rebasing to alpine 3.15 with php8. Restructure nginx configs ([see changes announcement](https://info.linuxserver.io/issues/2022-08-20-nginx-base))." }
   - { date: "10.08.22:", desc: "Added support for Dynu DNS validation." }
   - { date: "18.05.22:", desc: "Added support for Azure DNS validation." }

--- a/root/defaults/dns-conf/acmedns-registration.json
+++ b/root/defaults/dns-conf/acmedns-registration.json
@@ -1,0 +1,9 @@
+{
+    "yourdomain.com": {
+      "username":"yourusername",
+      "password":"yourpassword",
+      "fulldomain":"<guid>.acme.yourdomain.com",
+      "subdomain":"<guid>",
+      "allowfrom":[]
+    }
+  }

--- a/root/defaults/dns-conf/acmedns.ini
+++ b/root/defaults/dns-conf/acmedns.ini
@@ -1,0 +1,5 @@
+# See https://pypi.org/project/certbot-dns-acmedns/
+#     https://github.com/joohoi/acme-dns
+#     
+dns_acmedns_api_url = http://your-acme-dns-server.example.com/
+dns_acmedns_registration_file = /config/dns-conf/acmedns-registration.json

--- a/root/etc/cont-init.d/50-certbot
+++ b/root/etc/cont-init.d/50-certbot
@@ -28,7 +28,7 @@ cp -n /defaults/dns-conf/* /config/dns-conf/
 chown -R abc:abc /config/dns-conf
 
 # check to make sure DNSPLUGIN is selected if dns validation is used
-if [[ "$VALIDATION" = "dns" ]] && [[ ! "$DNSPLUGIN" =~ ^(aliyun|azure|cloudflare|cloudxns|cpanel|desec|digitalocean|directadmin|dnsimple|dnsmadeeasy|dnspod|domeneshop|dynu|gandi|gehirn|google|he|hetzner|infomaniak|inwx|ionos|linode|loopia|luadns|netcup|njalla|nsone|ovh|rfc2136|route53|sakuracloud|standalone|transip|vultr)$ ]]; then
+if [[ "$VALIDATION" = "dns" ]] && [[ ! "$DNSPLUGIN" =~ ^(acmedns|aliyun|azure|cloudflare|cloudxns|cpanel|desec|digitalocean|directadmin|dnsimple|dnsmadeeasy|dnspod|domeneshop|dynu|gandi|gehirn|google|he|hetzner|infomaniak|inwx|ionos|linode|loopia|luadns|netcup|njalla|nsone|ovh|rfc2136|route53|sakuracloud|standalone|transip|vultr)$ ]]; then
     echo "Please set the DNSPLUGIN variable to a valid plugin name. See docker info for more details."
     sleep infinity
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-swag/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Adding support for using acmedns DNS validation via the certbot-dns-acmedns certbot plug-in.  The plug-in was added from an existing python package (certbot-dns-acmedns) and incorporated via the Dockerfile RUN action (as with the other certbot plug-ins in this image).  Two additional files were added in the dns-conf directory (an INI and a JSON file) to allow for configuration of the plug-in.  

No original code is included in this PR (all code was sourced from existing repositories).

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
I have incorporated these changes into the docker image I use via Dockerfile build steps.  However, adding the acmedns plugin would allow others to more easily utilize an acmedns server to perform DNS validation of certificates.

NOTE: These changes do not incorporate the ACME DNS server component into the SWAG image.  A separate ACME DNS server is required in order to successfully use the plug-in.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
These changes were tested in a Ubuntu Server Docker environment using a separate ACME DNS server, a live domain, and the production Let's Encrypt service.  The image successfully built and a wildcard certificate for the domain was successfully retrieved.  The proxy image appeared to operate normally (i.e. serving web pages), and no negative impacts were observed.

These changes were NOT tested in an ARM/ARM64 environment.


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
https://pypi.org/project/certbot-dns-acmedns/
https://github.com/pan-net-security/certbot-dns-acmedns
https://gist.github.com/Nimrodda/af1c35264799fed663088c01b71c9e21#gistcomment-3358700
https://blog.bryanroessler.com/2019-02-09-automatic-certbot-namecheap-acme-dns/
https://hub.docker.com/r/joohoi/acme-dns/#configuration

