### PR TITLE
Add porkbun-dns-validation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -125,6 +125,7 @@ RUN \
     certbot-dns-njalla \
     certbot-dns-nsone \
     certbot-dns-ovh \
+    certbot-dns-porkbun \
     certbot-dns-rfc2136 \
     certbot-dns-route53 \
     certbot-dns-standalone \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -125,6 +125,7 @@ RUN \
     certbot-dns-njalla \
     certbot-dns-nsone \
     certbot-dns-ovh \
+    certbot-dns-porkbun \
     certbot-dns-rfc2136 \
     certbot-dns-route53 \
     certbot-dns-standalone \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -125,6 +125,7 @@ RUN \
     certbot-dns-njalla \
     certbot-dns-nsone \
     certbot-dns-ovh \
+    certbot-dns-porkbun \
     certbot-dns-rfc2136 \
     certbot-dns-route53 \
     certbot-dns-standalone \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -51,7 +51,7 @@ opt_param_usage_include_env: true
 opt_param_env_vars:
   - { env_var: "SUBDOMAINS", env_value: "www,", desc: "Subdomains you'd like the cert to cover (comma separated, no spaces) ie. `www,ftp,cloud`. For a wildcard cert, set this _exactly_ to `wildcard` (wildcard cert is available via `dns` and `duckdns` validation only)" }
   - { env_var: "CERTPROVIDER", env_value: "", desc: "Optionally define the cert provider. Set to `zerossl` for ZeroSSL certs (requires existing [ZeroSSL account](https://app.zerossl.com/signup) and the e-mail address entered in `EMAIL` env var). Otherwise defaults to Let's Encrypt." }
-  - { env_var: "DNSPLUGIN", env_value: "cloudflare", desc: "Required if `VALIDATION` is set to `dns`. Options are `aliyun`, `azure`, `cloudflare`, `cloudxns`, `cpanel`, `desec`, `digitalocean`, `directadmin`, `dnsimple`, `dnsmadeeasy`, `dnspod`, `domeneshop`, `gandi`, `gehirn`, `google`, `he`, `hetzner`, `infomaniak`, `inwx`, `ionos`, `linode`, `loopia`, `luadns`, `netcup`, `njalla`, `nsone`, `ovh`, `rfc2136`, `route53`, `sakuracloud`, `standalone`, `transip` and `vultr`. Also need to enter the credentials into the corresponding ini (or json for some plugins) file under `/config/dns-conf`." }
+  - { env_var: "DNSPLUGIN", env_value: "cloudflare", desc: "Required if `VALIDATION` is set to `dns`. Options are `aliyun`, `azure`, `cloudflare`, `cloudxns`, `cpanel`, `desec`, `digitalocean`, `directadmin`, `dnsimple`, `dnsmadeeasy`, `dnspod`, `domeneshop`, `gandi`, `gehirn`, `google`, `he`, `hetzner`, `infomaniak`, `inwx`, `ionos`, `linode`, `loopia`, `luadns`, `netcup`, `njalla`, `nsone`, `ovh`, `porkbun`, `rfc2136`, `route53`, `sakuracloud`, `standalone`, `transip` and `vultr`. Also need to enter the credentials into the corresponding ini (or json for some plugins) file under `/config/dns-conf`." }
   - { env_var: "PROPAGATION", env_value: "", desc: "Optionally override (in seconds) the default propagation time for the dns plugins." }
   - { env_var: "DUCKDNSTOKEN", env_value: "", desc: "Required if `VALIDATION` is set to `duckdns`. Retrieve your token from https://www.duckdns.org" }
   - { env_var: "EMAIL", env_value: "", desc: "Optional e-mail address used for cert expiration notifications (Required for ZeroSSL)." }
@@ -155,6 +155,7 @@ app_setup_nginx_reverse_proxy_block: ""
 
 # changelog
 changelogs:
+  - { date: "15.07.22:", desc: "Added support for Porkbun DNS validation." }
   - { date: "18.05.22:", desc: "Added support for Azure DNS validation." }
   - { date: "09.04.22:", desc: "Added certbot-dns-loopia for DNS01 validation." }
   - { date: "05.04.22:", desc: "Added support for standalone DNS validation." }

--- a/root/defaults/dns-conf/porkbun.ini
+++ b/root/defaults/dns-conf/porkbun.ini
@@ -1,0 +1,3 @@
+# Replace with your values
+dns_porkbun_key <porkbunapikey>
+dns_porkbun_secret <porkbunapikeysecret>

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -120,7 +120,7 @@ if ! grep -q 'PARAMETERS' "/config/nginx/dhparams.pem"; then
 fi
 
 # check to make sure DNSPLUGIN is selected if dns validation is used
-[[ "$VALIDATION" = "dns" ]] && [[ ! "$DNSPLUGIN" =~ ^(aliyun|azure|cloudflare|cloudxns|cpanel|desec|digitalocean|directadmin|dnsimple|dnsmadeeasy|dnspod|domeneshop|gandi|gehirn|google|he|hetzner|infomaniak|inwx|ionos|linode|loopia|luadns|netcup|njalla|nsone|ovh|rfc2136|route53|sakuracloud|standalone|transip|vultr)$ ]] && \
+[[ "$VALIDATION" = "dns" ]] && [[ ! "$DNSPLUGIN" =~ ^(aliyun|azure|cloudflare|cloudxns|cpanel|desec|digitalocean|directadmin|dnsimple|dnsmadeeasy|dnspod|domeneshop|gandi|gehirn|google|he|hetzner|infomaniak|inwx|ionos|linode|loopia|luadns|netcup|njalla|nsone|ovh|porkbun|rfc2136|route53|sakuracloud|standalone|transip|vultr)$ ]] && \
     echo "Please set the DNSPLUGIN variable to a valid plugin name. See docker info for more details." && \
     sleep infinity
 
@@ -222,31 +222,35 @@ sed -i 's|^certbot_dns_transip:||g' /config/dns-conf/transip.ini
 
 # setting the validation method to use
 if [ "$VALIDATION" = "dns" ]; then
-    if [ "$DNSPLUGIN" = "route53" ]; then
-        if [ -n "$PROPAGATION" ];then PROPAGATIONPARAM="--dns-${DNSPLUGIN}-propagation-seconds ${PROPAGATION}"; fi
-        PREFCHAL="--dns-${DNSPLUGIN} ${PROPAGATIONPARAM}"
+    if [[ "$DNSPLUGIN" =~ ^(azure)$ ]]; then
+        if [ -n "$PROPAGATION" ];then echo "Azure dns plugin does not support setting propagation time"; fi
+        PREFCHAL="-a dns-${DNSPLUGIN} --dns-${DNSPLUGIN}-credentials /config/dns-conf/${DNSPLUGIN}.ini"
     elif [[ "$DNSPLUGIN" =~ ^(cpanel)$ ]]; then
         if [ -n "$PROPAGATION" ];then PROPAGATIONPARAM="--certbot-dns-${DNSPLUGIN}:${DNSPLUGIN}-propagation-seconds ${PROPAGATION}"; fi
         PREFCHAL="-a certbot-dns-${DNSPLUGIN}:${DNSPLUGIN} --certbot-dns-${DNSPLUGIN}:${DNSPLUGIN}-credentials /config/dns-conf/${DNSPLUGIN}.ini ${PROPAGATIONPARAM}"
+    elif [[ "$DNSPLUGIN" =~ ^(directadmin)$ ]]; then
+        if [ -n "$PROPAGATION" ];then PROPAGATIONPARAM="--${DNSPLUGIN}-propagation-seconds ${PROPAGATION}"; fi
+        PREFCHAL="-a ${DNSPLUGIN} --${DNSPLUGIN}-credentials /config/dns-conf/${DNSPLUGIN}.ini ${PROPAGATIONPARAM}"
     elif [[ "$DNSPLUGIN" =~ ^(gandi)$ ]]; then
         if [ -n "$PROPAGATION" ];then echo "Gandi dns plugin does not support setting propagation time"; fi
         PREFCHAL="-a certbot-plugin-${DNSPLUGIN}:dns --certbot-plugin-${DNSPLUGIN}:dns-credentials /config/dns-conf/${DNSPLUGIN}.ini"
     elif [[ "$DNSPLUGIN" =~ ^(google)$ ]]; then
         if [ -n "$PROPAGATION" ];then PROPAGATIONPARAM="--dns-${DNSPLUGIN}-propagation-seconds ${PROPAGATION}"; fi
         PREFCHAL="--dns-${DNSPLUGIN} --dns-${DNSPLUGIN}-credentials /config/dns-conf/${DNSPLUGIN}.json ${PROPAGATIONPARAM}"
-    elif [[ "$DNSPLUGIN" =~ ^(aliyun|desec|dnspod|domeneshop|he|hetzner|infomaniak|inwx|ionos|loopia|netcup|njalla|transip|vultr)$ ]]; then
+    elif [[ "$DNSPLUGIN" =~ ^(porkbun)$ ]]; then
         if [ -n "$PROPAGATION" ];then PROPAGATIONPARAM="--dns-${DNSPLUGIN}-propagation-seconds ${PROPAGATION}"; fi
-        PREFCHAL="-a dns-${DNSPLUGIN} --dns-${DNSPLUGIN}-credentials /config/dns-conf/${DNSPLUGIN}.ini ${PROPAGATIONPARAM}"
+            if [ -n "$EMAIL" ];then EMAILPARAM="--email ${EMAIL} "; else EMAILPARAM="--register-unsafely-without-email "; fi
+            PREFCHAL="--non-interactive --agree-tos ${EMAILPARAM} --preferred-challenges dns --authenticator dns-${DNSPLUGIN} --dns-${DNSPLUGIN}-credentials /config/dns-conf/${DNSPLUGIN}.ini ${PROPAGATIONPARAM}"
+    elif [ "$DNSPLUGIN" = "route53" ]; then
+        if [ -n "$PROPAGATION" ];then PROPAGATIONPARAM="--dns-${DNSPLUGIN}-propagation-seconds ${PROPAGATION}"; fi
+        PREFCHAL="--dns-${DNSPLUGIN} ${PROPAGATIONPARAM}"
     elif [[ "$DNSPLUGIN" =~ ^(standalone)$ ]]; then
         if [ -n "$PROPAGATION" ];then echo "standalone dns plugin does not support setting propagation time"; fi
         PREFCHAL="-a dns-${DNSPLUGIN}"
-    elif [[ "$DNSPLUGIN" =~ ^(directadmin)$ ]]; then
-        if [ -n "$PROPAGATION" ];then PROPAGATIONPARAM="--${DNSPLUGIN}-propagation-seconds ${PROPAGATION}"; fi
-        PREFCHAL="-a ${DNSPLUGIN} --${DNSPLUGIN}-credentials /config/dns-conf/${DNSPLUGIN}.ini ${PROPAGATIONPARAM}"
-    elif [[ "$DNSPLUGIN" =~ ^(azure)$ ]]; then
-        if [ -n "$PROPAGATION" ];then echo "Azure dns plugin does not support setting propagation time"; fi
-        PREFCHAL="-a dns-${DNSPLUGIN} --dns-${DNSPLUGIN}-credentials /config/dns-conf/${DNSPLUGIN}.ini"
-    else
+    elif [[ "$DNSPLUGIN" =~ ^(aliyun|desec|dnspod|domeneshop|he|hetzner|infomaniak|inwx|ionos|loopia|netcup|njalla|transip|vultr)$ ]]; then
+        if [ -n "$PROPAGATION" ];then PROPAGATIONPARAM="--dns-${DNSPLUGIN}-propagation-seconds ${PROPAGATION}"; fi
+        PREFCHAL="-a dns-${DNSPLUGIN} --dns-${DNSPLUGIN}-credentials /config/dns-conf/${DNSPLUGIN}.ini ${PROPAGATIONPARAM}"
+	else
         if [ -n "$PROPAGATION" ];then PROPAGATIONPARAM="--dns-${DNSPLUGIN}-propagation-seconds ${PROPAGATION}"; fi
         PREFCHAL="--dns-${DNSPLUGIN} --dns-${DNSPLUGIN}-credentials /config/dns-conf/${DNSPLUGIN}.ini ${PROPAGATIONPARAM}"
     fi


### PR DESCRIPTION
------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-swag/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
- Add Porkbun dns validation as an option by using certbot_dns_porkbun https://github.com/infinityofspace/certbot_dns_porkbun
- Alphabetized the listing of dns validation check statements within 50-config.

## Benefits of this PR and context:
Porkbun is an established ICANN which provides API access for the management of domains. Utilizing a python plugin (certbot_dns_porkbun) allows a user another option for a supported DNS registrar.

## How Has This Been Tested?
```
git clone --branch porkbun-dns-validation https://github.com/FlavorMeld/docker-swag.git
cd docker-swag
docker build local/swag:dev .
```


## Source / References:
[https://github.com/infinityofspace/certbot_dns_porkbun](https://github.com/infinityofspace/certbot_dns_porkbun)
[https://pypi.org/project/certbot-dns-porkbun/](https://pypi.org/project/certbot-dns-porkbun/)
[https://github.com/infinityofspace/certbot_dns_porkbun/issues/49](https://github.com/infinityofspace/certbot_dns_porkbun/issues/49)

https://github.com/linuxserver/docker-swag/issues/208
