### PR TITLE
Add Dynu DNS Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,6 +112,7 @@ RUN \
     certbot-dns-dnsmadeeasy \
     certbot-dns-dnspod \
     certbot-dns-domeneshop \
+    certbot-dns-dynu \
     certbot-dns-google \
     certbot-dns-he \
     certbot-dns-hetzner \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -112,6 +112,7 @@ RUN \
     certbot-dns-dnsmadeeasy \
     certbot-dns-dnspod \
     certbot-dns-domeneshop \
+    certbot-dns-dynu \
     certbot-dns-google \
     certbot-dns-he \
     certbot-dns-hetzner \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -112,6 +112,7 @@ RUN \
     certbot-dns-dnsmadeeasy \
     certbot-dns-dnspod \
     certbot-dns-domeneshop \
+    certbot-dns-dynu \
     certbot-dns-google \
     certbot-dns-he \
     certbot-dns-hetzner \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -51,7 +51,7 @@ opt_param_usage_include_env: true
 opt_param_env_vars:
   - { env_var: "SUBDOMAINS", env_value: "www,", desc: "Subdomains you'd like the cert to cover (comma separated, no spaces) ie. `www,ftp,cloud`. For a wildcard cert, set this _exactly_ to `wildcard` (wildcard cert is available via `dns` and `duckdns` validation only)" }
   - { env_var: "CERTPROVIDER", env_value: "", desc: "Optionally define the cert provider. Set to `zerossl` for ZeroSSL certs (requires existing [ZeroSSL account](https://app.zerossl.com/signup) and the e-mail address entered in `EMAIL` env var). Otherwise defaults to Let's Encrypt." }
-  - { env_var: "DNSPLUGIN", env_value: "cloudflare", desc: "Required if `VALIDATION` is set to `dns`. Options are `aliyun`, `azure`, `cloudflare`, `cloudxns`, `cpanel`, `desec`, `digitalocean`, `directadmin`, `dnsimple`, `dnsmadeeasy`, `dnspod`, `domeneshop`, `gandi`, `gehirn`, `google`, `he`, `hetzner`, `infomaniak`, `inwx`, `ionos`, `linode`, `loopia`, `luadns`, `netcup`, `njalla`, `nsone`, `ovh`, `rfc2136`, `route53`, `sakuracloud`, `standalone`, `transip` and `vultr`. Also need to enter the credentials into the corresponding ini (or json for some plugins) file under `/config/dns-conf`." }
+  - { env_var: "DNSPLUGIN", env_value: "cloudflare", desc: "Required if `VALIDATION` is set to `dns`. Options are `aliyun`, `azure`, `cloudflare`, `cloudxns`, `cpanel`, `desec`, `digitalocean`, `directadmin`, `dnsimple`, `dnsmadeeasy`, `dnspod`, `domeneshop`, `dynu`, `gandi`, `gehirn`, `google`, `he`, `hetzner`, `infomaniak`, `inwx`, `ionos`, `linode`, `loopia`, `luadns`, `netcup`, `njalla`, `nsone`, `ovh`, `rfc2136`, `route53`, `sakuracloud`, `standalone`, `transip` and `vultr`. Also need to enter the credentials into the corresponding ini (or json for some plugins) file under `/config/dns-conf`." }
   - { env_var: "PROPAGATION", env_value: "", desc: "Optionally override (in seconds) the default propagation time for the dns plugins." }
   - { env_var: "DUCKDNSTOKEN", env_value: "", desc: "Required if `VALIDATION` is set to `duckdns`. Retrieve your token from https://www.duckdns.org" }
   - { env_var: "EMAIL", env_value: "", desc: "Optional e-mail address used for cert expiration notifications (Required for ZeroSSL)." }
@@ -155,6 +155,7 @@ app_setup_nginx_reverse_proxy_block: ""
 
 # changelog
 changelogs:
+  - { date: "10.08.22:", desc: "Added support for Dynu DNS validation." }
   - { date: "18.05.22:", desc: "Added support for Azure DNS validation." }
   - { date: "09.04.22:", desc: "Added certbot-dns-loopia for DNS01 validation." }
   - { date: "05.04.22:", desc: "Added support for standalone DNS validation." }

--- a/root/defaults/dns-conf/dynu.ini
+++ b/root/defaults/dns-conf/dynu.ini
@@ -1,0 +1,3 @@
+# Instructions: https://github.com/bikram990/certbot-dns-dynu#configuration
+# Replace with your API token from your dynu account.
+dns_dynu_auth_token = AbCbASsd!@34

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -120,7 +120,7 @@ if ! grep -q 'PARAMETERS' "/config/nginx/dhparams.pem"; then
 fi
 
 # check to make sure DNSPLUGIN is selected if dns validation is used
-[[ "$VALIDATION" = "dns" ]] && [[ ! "$DNSPLUGIN" =~ ^(aliyun|azure|cloudflare|cloudxns|cpanel|desec|digitalocean|directadmin|dnsimple|dnsmadeeasy|dnspod|domeneshop|gandi|gehirn|google|he|hetzner|infomaniak|inwx|ionos|linode|loopia|luadns|netcup|njalla|nsone|ovh|rfc2136|route53|sakuracloud|standalone|transip|vultr)$ ]] && \
+[[ "$VALIDATION" = "dns" ]] && [[ ! "$DNSPLUGIN" =~ ^(aliyun|azure|cloudflare|cloudxns|cpanel|desec|digitalocean|directadmin|dnsimple|dnsmadeeasy|dnspod|domeneshop|dynu|gandi|gehirn|google|he|hetzner|infomaniak|inwx|ionos|linode|loopia|luadns|netcup|njalla|nsone|ovh|rfc2136|route53|sakuracloud|standalone|transip|vultr)$ ]] && \
     echo "Please set the DNSPLUGIN variable to a valid plugin name. See docker info for more details." && \
     sleep infinity
 
@@ -234,7 +234,7 @@ if [ "$VALIDATION" = "dns" ]; then
     elif [[ "$DNSPLUGIN" =~ ^(google)$ ]]; then
         if [ -n "$PROPAGATION" ];then PROPAGATIONPARAM="--dns-${DNSPLUGIN}-propagation-seconds ${PROPAGATION}"; fi
         PREFCHAL="--dns-${DNSPLUGIN} --dns-${DNSPLUGIN}-credentials /config/dns-conf/${DNSPLUGIN}.json ${PROPAGATIONPARAM}"
-    elif [[ "$DNSPLUGIN" =~ ^(aliyun|desec|dnspod|domeneshop|he|hetzner|infomaniak|inwx|ionos|loopia|netcup|njalla|transip|vultr)$ ]]; then
+    elif [[ "$DNSPLUGIN" =~ ^(aliyun|desec|dnspod|domeneshop|dynu|he|hetzner|infomaniak|inwx|ionos|loopia|netcup|njalla|transip|vultr)$ ]]; then
         if [ -n "$PROPAGATION" ];then PROPAGATIONPARAM="--dns-${DNSPLUGIN}-propagation-seconds ${PROPAGATION}"; fi
         PREFCHAL="-a dns-${DNSPLUGIN} --dns-${DNSPLUGIN}-credentials /config/dns-conf/${DNSPLUGIN}.ini ${PROPAGATIONPARAM}"
     elif [[ "$DNSPLUGIN" =~ ^(standalone)$ ]]; then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-swag/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:

* Add Dynu DNS validation via certbot-dns-dynu: https://github.com/bikram990/certbot-dns-dynu to dockerfiles.
* Added 'dynu' to valid dns plugin lists in 50-config and readme-vars.yml

## Benefits of this PR and context:
Allow other users with Dynu Dynamic DNS service to utilize this container for their own environments and use cases.

## How Has This Been Tested?

```
sudo docker build --no-cache --pull -t linuxserver/swag:latest .
```
compose file:
```
version: "2.1"
networks:
  default:
    name: proxynet
services:
  nginx:
    image: [IMAGE ID of build]
    container_name: swag
    hostname: swag
    cap_add:
      - NET_ADMIN
    environment:
      - PUID=1000
      - PGID=1000
      - TZ=America/Los_Angeles
      - URL=DOMAIN
      - VALIDATION=dns
      - SUBDOMAINS=test
      - DNSPLUGIN=dynu
      - PROPAGATION=120
      - EMAIL=[REDACTED]
      - ONLY_SUBDOMAINS=true
      - STAGING=true
    volumes:
      - /usr/docker/data/swag/config:/config:rw
    ports:
      - 80:80
      - 443:443
    restart: unless-stopped
```
```
docker-compose up -d
```
Certificates generated as expected.
stdout of ```docker-compose up -d```:
stdout (from swag container):
```
Aug 11 21:01:50 blackmesa docker-compose[79840]: Attaching to swag
Aug 11 21:01:52 blackmesa docker-compose[79840]: swag  | s6-rc: info: service s6rc-oneshot-runner: starting
Aug 11 21:01:52 blackmesa docker-compose[79840]: swag  | s6-rc: info: service s6rc-oneshot-runner successfully started
Aug 11 21:01:52 blackmesa docker-compose[79840]: swag  | s6-rc: info: service fix-attrs: starting
Aug 11 21:01:52 blackmesa docker-compose[79840]: swag  | s6-rc: info: service 00-legacy: starting
Aug 11 21:01:52 blackmesa docker-compose[79840]: swag  | s6-rc: info: service 00-legacy successfully started
Aug 11 21:01:52 blackmesa docker-compose[79840]: swag  | s6-rc: info: service fix-attrs successfully started
Aug 11 21:01:52 blackmesa docker-compose[79840]: swag  | s6-rc: info: service legacy-cont-init: starting
Aug 11 21:01:52 blackmesa docker-compose[79840]: swag  | cont-init: info: running /etc/cont-init.d/01-envfile
Aug 11 21:01:52 blackmesa docker-compose[79840]: swag  | cont-init: info: /etc/cont-init.d/01-envfile exited 0
Aug 11 21:01:52 blackmesa docker-compose[79840]: swag  | cont-init: info: running /etc/cont-init.d/02-tamper-check
Aug 11 21:01:52 blackmesa docker-compose[79840]: swag  | cont-init: info: /etc/cont-init.d/02-tamper-check exited 0
Aug 11 21:01:52 blackmesa docker-compose[79840]: swag  | cont-init: info: running /etc/cont-init.d/10-adduser
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  |
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | -------------------------------------
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  |           _         ()
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  |          | |  ___   _    __
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  |          | | / __| | |  /  \
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  |          | | \__ \ | | | () |
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  |          |_| |___/ |_|  \__/
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  |
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  |
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | Brought to you by linuxserver.io
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | -------------------------------------
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  |
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | To support the app dev(s) visit:
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | Certbot: https://supporters.eff.org/donate/support-work-on-certbot
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  |
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | To support LSIO projects visit:
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | https://www.linuxserver.io/donate/
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | -------------------------------------
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | GID/UID
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | -------------------------------------
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  |
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | User uid:    1000
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | User gid:    1000
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | -------------------------------------
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  |
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | cont-init: info: /etc/cont-init.d/10-adduser exited 0
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | cont-init: info: running /etc/cont-init.d/20-config
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | cont-init: info: /etc/cont-init.d/20-config exited 0
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | cont-init: info: running /etc/cont-init.d/30-keygen
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | using keys found in /config/keys
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | cont-init: info: /etc/cont-init.d/30-keygen exited 0
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | cont-init: info: running /etc/cont-init.d/50-config
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | Variables set:
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | PUID=1000
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | PGID=1000
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | TZ=America/Los_Angeles
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | URL=DOMAIN
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | SUBDOMAINS=test
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | EXTRA_DOMAINS=
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | ONLY_SUBDOMAINS=true
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | VALIDATION=dns
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | CERTPROVIDER=
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | DNSPLUGIN=dynu
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | EMAIL=[REDACTED]
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | STAGING=true
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  |
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | NOTICE: Staging is active
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | Using Let's Encrypt as the cert provider
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | SUBDOMAINS entered, processing
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | SUBDOMAINS entered, processing
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | Only subdomains, no URL in cert
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | Sub-domains processed are:  -d test.DOMAIN
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | E-mail address entered: [REDACTED]
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | dns validation via dynu plugin is selected
Aug 11 21:01:53 blackmesa docker-compose[79840]: swag  | Generating new certificate
Aug 11 21:01:57 blackmesa docker-compose[79840]: swag  | Saving debug log to /var/log/letsencrypt/letsencrypt.log
Aug 11 21:01:57 blackmesa docker-compose[79840]: swag  | Requesting a certificate for test.DOMAIN
Aug 11 21:02:00 blackmesa docker-compose[79840]: swag  | Waiting 120 seconds for DNS changes to propagate
Aug 11 21:04:12 blackmesa docker-compose[79840]: swag  |
Aug 11 21:04:12 blackmesa docker-compose[79840]: swag  | Successfully received certificate.
Aug 11 21:04:12 blackmesa docker-compose[79840]: swag  | Certificate is saved at: /etc/letsencrypt/live/test.DOMAIN/fullchain.pem
Aug 11 21:04:12 blackmesa docker-compose[79840]: swag  | Key is saved at:         /etc/letsencrypt/live/test.DOMAIN/privkey.pem
Aug 11 21:04:12 blackmesa docker-compose[79840]: swag  | This certificate expires on 2022-11-09.
Aug 11 21:04:12 blackmesa docker-compose[79840]: swag  | These files will be updated when the certificate renews.
Aug 11 21:04:12 blackmesa docker-compose[79840]: swag  | NEXT STEPS:
Aug 11 21:04:12 blackmesa docker-compose[79840]: swag  | - The certificate will need to be renewed before it expires. Certbot can automatically renew the certificate in the background, but you may need to take steps to enable that functionality. See https://certbot.org/renewal-setup for instructions.
Aug 11 21:04:12 blackmesa docker-compose[79840]: swag  |
Aug 11 21:04:12 blackmesa docker-compose[79840]: swag  | - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Aug 11 21:04:12 blackmesa docker-compose[79840]: swag  | If you like Certbot, please consider supporting our work by:
Aug 11 21:04:12 blackmesa docker-compose[79840]: swag  |  * Donating to ISRG / Let's Encrypt:   https://letsencrypt.org/donate
Aug 11 21:04:12 blackmesa docker-compose[79840]: swag  |  * Donating to EFF:                    https://eff.org/donate-le
Aug 11 21:04:12 blackmesa docker-compose[79840]: swag  | - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Aug 11 21:04:13 blackmesa docker-compose[79840]: swag  | New certificate generated; starting nginx
Aug 11 21:04:14 blackmesa docker-compose[79840]: swag  | cont-init: info: /etc/cont-init.d/50-config exited 0
Aug 11 21:04:14 blackmesa docker-compose[79840]: swag  | cont-init: info: running /etc/cont-init.d/60-renew
Aug 11 21:04:14 blackmesa docker-compose[79840]: swag  | The cert does not expire within the next day. Letting the cron script handle the renewal attempts overnight (2:08am).
Aug 11 21:04:14 blackmesa docker-compose[79840]: swag  | cont-init: info: /etc/cont-init.d/60-renew exited 0
Aug 11 21:04:14 blackmesa docker-compose[79840]: swag  | cont-init: info: running /etc/cont-init.d/70-templates
Aug 11 21:04:14 blackmesa docker-compose[79840]: swag  | cont-init: info: /etc/cont-init.d/70-templates exited 0
Aug 11 21:04:14 blackmesa docker-compose[79840]: swag  | cont-init: info: running /etc/cont-init.d/90-custom-folders
Aug 11 21:04:14 blackmesa docker-compose[79840]: swag  | cont-init: info: /etc/cont-init.d/90-custom-folders exited 0
Aug 11 21:04:14 blackmesa docker-compose[79840]: swag  | cont-init: info: running /etc/cont-init.d/99-custom-files
Aug 11 21:04:14 blackmesa docker-compose[79840]: swag  | [custom-init] no custom files found exiting...
Aug 11 21:04:14 blackmesa docker-compose[79840]: swag  | cont-init: info: /etc/cont-init.d/99-custom-files exited 0
Aug 11 21:04:14 blackmesa docker-compose[79840]: swag  | s6-rc: info: service legacy-cont-init successfully started
Aug 11 21:04:14 blackmesa docker-compose[79840]: swag  | s6-rc: info: service init-mods: starting
Aug 11 21:04:14 blackmesa docker-compose[79840]: swag  | s6-rc: info: service init-mods successfully started
Aug 11 21:04:14 blackmesa docker-compose[79840]: swag  | s6-rc: info: service init-mods-package-install: starting
Aug 11 21:04:14 blackmesa docker-compose[79840]: swag  | s6-rc: info: service init-mods-package-install successfully started
Aug 11 21:04:14 blackmesa docker-compose[79840]: swag  | s6-rc: info: service init-mods-end: starting
Aug 11 21:04:14 blackmesa docker-compose[79840]: swag  | s6-rc: info: service init-mods-end successfully started
Aug 11 21:04:14 blackmesa docker-compose[79840]: swag  | s6-rc: info: service init-services: starting
Aug 11 21:04:14 blackmesa docker-compose[79840]: swag  | s6-rc: info: service init-services successfully started
Aug 11 21:04:14 blackmesa docker-compose[79840]: swag  | s6-rc: info: service legacy-services: starting
Aug 11 21:04:14 blackmesa docker-compose[79840]: swag  | services-up: info: copying legacy longrun cron (no readiness notification)
Aug 11 21:04:14 blackmesa docker-compose[79840]: swag  | services-up: info: copying legacy longrun fail2ban (no readiness notification)
Aug 11 21:04:14 blackmesa docker-compose[79840]: swag  | services-up: info: copying legacy longrun nginx (no readiness notification)
Aug 11 21:04:14 blackmesa docker-compose[79840]: swag  | services-up: info: copying legacy longrun php-fpm (no readiness notification)
Aug 11 21:04:14 blackmesa docker-compose[79840]: swag  | s6-rc: info: service legacy-services successfully started
Aug 11 21:04:14 blackmesa docker-compose[79840]: swag  | s6-rc: info: service 99-ci-service-check: starting
Aug 11 21:04:14 blackmesa docker-compose[79840]: swag  | [ls.io-init] done.
Aug 11 21:04:14 blackmesa docker-compose[79840]: swag  | s6-rc: info: service 99-ci-service-check successfully started
Aug 11 21:04:14 blackmesa docker-compose[79840]: swag  | Server ready
```


## Source / References:
* https://github.com/bikram990/certbot-dns-dynu
* https://pypi.org/project/certbot-dns-dynu/

