### PR TITLE
Added do (domainoffensive) validation plugin for certbot. closes #262

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,6 +114,7 @@ RUN \
     certbot-dns-dnsimple \
     certbot-dns-dnsmadeeasy \
     certbot-dns-dnspod \
+    certbot-dns-do \
     certbot-dns-domeneshop \
     certbot-dns-dynu \
     certbot-dns-google \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -114,6 +114,7 @@ RUN \
     certbot-dns-dnsimple \
     certbot-dns-dnsmadeeasy \
     certbot-dns-dnspod \
+    certbot-dns-do \
     certbot-dns-domeneshop \
     certbot-dns-dynu \
     certbot-dns-google \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -115,6 +115,7 @@ RUN \
     certbot-dns-dnsmadeeasy \
     certbot-dns-dnspod \
     certbot-dns-domeneshop \
+    certbot-dns-do \
     certbot-dns-dynu \
     certbot-dns-google \
     certbot-dns-he \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -51,7 +51,7 @@ opt_param_usage_include_env: true
 opt_param_env_vars:
   - { env_var: "SUBDOMAINS", env_value: "www,", desc: "Subdomains you'd like the cert to cover (comma separated, no spaces) ie. `www,ftp,cloud`. For a wildcard cert, set this _exactly_ to `wildcard` (wildcard cert is available via `dns` and `duckdns` validation only)" }
   - { env_var: "CERTPROVIDER", env_value: "", desc: "Optionally define the cert provider. Set to `zerossl` for ZeroSSL certs (requires existing [ZeroSSL account](https://app.zerossl.com/signup) and the e-mail address entered in `EMAIL` env var). Otherwise defaults to Let's Encrypt." }
-  - { env_var: "DNSPLUGIN", env_value: "cloudflare", desc: "Required if `VALIDATION` is set to `dns`. Options are `acmedns`,`aliyun`, `azure`, `cloudflare`, `cloudxns`, `cpanel`, `desec`, `digitalocean`, `directadmin`, `dnsimple`, `dnsmadeeasy`, `dnspod`, `domeneshop`, `dynu`, `gandi`, `gehirn`, `google`, `he`, `hetzner`, `infomaniak`, `inwx`, `ionos`, `linode`, `loopia`, `luadns`, `netcup`, `njalla`, `nsone`, `ovh`, `rfc2136`, `route53`, `sakuracloud`, `standalone`, `transip` and `vultr`. Also need to enter the credentials into the corresponding ini (or json for some plugins) file under `/config/dns-conf`." }
+  - { env_var: "DNSPLUGIN", env_value: "cloudflare", desc: "Required if `VALIDATION` is set to `dns`. Options are `acmedns`,`aliyun`, `azure`, `cloudflare`, `cloudxns`, `cpanel`, `desec`, `digitalocean`, `directadmin`, `dnsimple`, `dnsmadeeasy`, `dnspod`, `do`, `domeneshop`, `dynu`, `gandi`, `gehirn`, `google`, `he`, `hetzner`, `infomaniak`, `inwx`, `ionos`, `linode`, `loopia`, `luadns`, `netcup`, `njalla`, `nsone`, `ovh`, `rfc2136`, `route53`, `sakuracloud`, `standalone`, `transip` and `vultr`. Also need to enter the credentials into the corresponding ini (or json for some plugins) file under `/config/dns-conf`." }
   - { env_var: "PROPAGATION", env_value: "", desc: "Optionally override (in seconds) the default propagation time for the dns plugins." }
   - { env_var: "DUCKDNSTOKEN", env_value: "", desc: "Required if `VALIDATION` is set to `duckdns`. Retrieve your token from https://www.duckdns.org" }
   - { env_var: "EMAIL", env_value: "", desc: "Optional e-mail address used for cert expiration notifications (Required for ZeroSSL)." }
@@ -155,6 +155,7 @@ app_setup_nginx_reverse_proxy_block: ""
 
 # changelog
 changelogs:
+  - { date: "22.09.22:", desc: "Added support for DO DNS validation." }
   - { date: "22.09.22:", desc: "Added certbot-dns-acmedns for DNS01 validation." }
   - { date: "20.08.22:", desc: "[Existing users should update:](https://github.com/linuxserver/docker-swag/blob/master/README.md#updating-configs) nginx.conf - Rebasing to alpine 3.15 with php8. Restructure nginx configs ([see changes announcement](https://info.linuxserver.io/issues/2022-08-20-nginx-base))." }
   - { date: "10.08.22:", desc: "Added support for Dynu DNS validation." }

--- a/root/defaults/dns-conf/do.ini
+++ b/root/defaults/dns-conf/do.ini
@@ -1,0 +1,3 @@
+# Instructions: https://github.com/georgeto/certbot-dns-do/blob/master/certbot_dns_do/__init__.py#L32
+# Replace with your values
+dns_do_api_token = YOUR_DO_LETSENCRYPT_API_KEY

--- a/root/etc/cont-init.d/50-certbot
+++ b/root/etc/cont-init.d/50-certbot
@@ -28,9 +28,10 @@ cp -n /defaults/dns-conf/* /config/dns-conf/
 chown -R abc:abc /config/dns-conf
 
 # check to make sure DNSPLUGIN is selected if dns validation is used
-if [[ "$VALIDATION" = "dns" ]] && [[ ! "$DNSPLUGIN" =~ ^(acmedns|aliyun|azure|cloudflare|cloudxns|cpanel|desec|digitalocean|directadmin|dnsimple|dnsmadeeasy|dnspod|domeneshop|dynu|gandi|gehirn|google|he|hetzner|infomaniak|inwx|ionos|linode|loopia|luadns|netcup|njalla|nsone|ovh|rfc2136|route53|sakuracloud|standalone|transip|vultr)$ ]]; then
+if [[ "$VALIDATION" = "dns" ]] && [[ ! "$DNSPLUGIN" =~ ^(acmedns|aliyun|azure|cloudflare|cloudxns|cpanel|desec|digitalocean|directadmin|dnsimple|dnsmadeeasy|dnspod|do|domeneshop|dynu|gandi|gehirn|google|he|hetzner|infomaniak|inwx|ionos|linode|loopia|luadns|netcup|njalla|nsone|ovh|rfc2136|route53|sakuracloud|standalone|transip|vultr)$ ]]; then
     echo "Please set the DNSPLUGIN variable to a valid plugin name. See docker info for more details."
     sleep infinity
+
 fi
 
 # create original config file if it doesn't exist, move non-hidden legacy file to hidden
@@ -139,7 +140,7 @@ if [ "$VALIDATION" = "dns" ]; then
     elif [[ "$DNSPLUGIN" =~ ^(google)$ ]]; then
         if [ -n "$PROPAGATION" ];then PROPAGATIONPARAM="--dns-${DNSPLUGIN}-propagation-seconds ${PROPAGATION}"; fi
         PREFCHAL="--dns-${DNSPLUGIN} --dns-${DNSPLUGIN}-credentials /config/dns-conf/${DNSPLUGIN}.json ${PROPAGATIONPARAM}"
-    elif [[ "$DNSPLUGIN" =~ ^(aliyun|desec|dnspod|domeneshop|dynu|he|hetzner|infomaniak|inwx|ionos|loopia|netcup|njalla|transip|vultr)$ ]]; then
+    elif [[ "$DNSPLUGIN" =~ ^(aliyun|desec|dnspod|do|domeneshop|dynu|he|hetzner|infomaniak|inwx|ionos|loopia|netcup|njalla|transip|vultr)$ ]]; then
         if [ -n "$PROPAGATION" ];then PROPAGATIONPARAM="--dns-${DNSPLUGIN}-propagation-seconds ${PROPAGATION}"; fi
         PREFCHAL="-a dns-${DNSPLUGIN} --dns-${DNSPLUGIN}-credentials /config/dns-conf/${DNSPLUGIN}.ini ${PROPAGATIONPARAM}"
     elif [[ "$DNSPLUGIN" =~ ^(standalone)$ ]]; then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-swag/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Adding support for using [DO](https://do.de) (DomainOffensive) DNS validation.

- Add do DNS validation via [certbot-dns-do](https://github.com/georgeto/certbot-dns-do)  to Dockerfiles.
- Added 'do' to valid dns plugin lists in 50-config and readme-vars.yml
- Added 'do.ini' config file to dns-conf directory

## Benefits of this PR and context:
Allow other users with DO DNS service to utilize this container for their own environments and use cases.

## How Has This Been Tested?

~~~
sudo docker build --no-cache --pull -t linuxserver/swag:latest .
~~~

compose file:

~~~
---
version: "2.1"
services:
  swag:
#    image: lscr.io/linuxserver/swag
    image: linuxserver/swag
    container_name: swag
    cap_add:
      - NET_ADMIN
    environment:
#      - PUID=1000
#      - PGID=1000
      - TZ=Europe/Berlin
      - URL=domain.tld
      - SUBDOMAINS=wasub
#      - EXTRA_DOMAINS=<extradomains> #optional
      - ONLY_SUBDOMAINS=true #optional
      - VALIDATION=dns
#      - CERTPROVIDER= #optional
      - DNSPLUGIN=do
#      - EMAIL=<e-mail> #optional
      - STAGING=true #optional
    volumes:
      - ./data:/config
    ports:
      - 443:443
      - 80:80 #optional
    restart: unless-stopped
~~~

~~~
docker-compose up -d
~~~

~~~
Attaching to swag
swag  | [custom-init] no custom services found, skipping...
swag  | s6-rc: info: service s6rc-oneshot-runner: starting
swag  | s6-rc: info: service s6rc-oneshot-runner successfully started
swag  | s6-rc: info: service fix-attrs: starting
swag  | s6-rc: info: service 00-legacy: starting
swag  | s6-rc: info: service 00-legacy successfully started
swag  | s6-rc: info: service fix-attrs successfully started
swag  | s6-rc: info: service legacy-cont-init: starting
swag  | cont-init: info: running /etc/cont-init.d/01-envfile
swag  | cont-init: info: /etc/cont-init.d/01-envfile exited 0
swag  | cont-init: info: running /etc/cont-init.d/02-tamper-check
swag  | cont-init: info: /etc/cont-init.d/02-tamper-check exited 0
swag  | cont-init: info: running /etc/cont-init.d/10-adduser
swag  | usermod: no changes
swag  | 
swag  | -------------------------------------
swag  |           _         ()
swag  |          | |  ___   _    __
swag  |          | | / __| | |  /  \
swag  |          | | \__ \ | | | () |
swag  |          |_| |___/ |_|  \__/
swag  | 
swag  | 
swag  | Brought to you by linuxserver.io
swag  | -------------------------------------
swag  | 
swag  | To support the app dev(s) visit:
swag  | Certbot: https://supporters.eff.org/donate/support-work-on-certbot
swag  | 
swag  | To support LSIO projects visit:
swag  | https://www.linuxserver.io/donate/
swag  | -------------------------------------
swag  | GID/UID
swag  | -------------------------------------
swag  | 
swag  | User uid:    911
swag  | User gid:    911
swag  | -------------------------------------
swag  | 
swag  | cont-init: info: /etc/cont-init.d/10-adduser exited 0
swag  | cont-init: info: running /etc/cont-init.d/20-config
swag  | cont-init: info: /etc/cont-init.d/20-config exited 0
swag  | cont-init: info: running /etc/cont-init.d/30-keygen
swag  | using keys found in /config/keys
swag  | cont-init: info: /etc/cont-init.d/30-keygen exited 0
swag  | cont-init: info: running /etc/cont-init.d/50-config
swag  | Variables set:
swag  | PUID=
swag  | PGID=
swag  | TZ=Europe/Berlin
swag  | URL=domain.tld
swag  | SUBDOMAINS=wasub
swag  | EXTRA_DOMAINS=
swag  | ONLY_SUBDOMAINS=true
swag  | VALIDATION=dns
swag  | CERTPROVIDER=
swag  | DNSPLUGIN=do
swag  | EMAIL=
swag  | STAGING=true
swag  | 
swag  | NOTICE: Staging is active
swag  | Using Let's Encrypt as the cert provider
swag  | SUBDOMAINS entered, processing
swag  | SUBDOMAINS entered, processing
swag  | Only subdomains, no URL in cert
swag  | Sub-domains processed are:  -d wasub.domain.tld
swag  | No e-mail address entered or address invalid
swag  | dns validation via do plugin is selected
swag  | Different validation parameters entered than what was used before. Revoking and deleting existing certificate, and an updated one will be created
swag  | Generating new certificate
swag  | Saving debug log to /var/log/letsencrypt/letsencrypt.log
swag  | Account registered.
swag  | Requesting a certificate for wasub.domain.tld
swag  | Unsafe permissions on credentials configuration file: /config/dns-conf/do.ini
swag  | Waiting 10 seconds for DNS changes to propagate
swag  | 
swag  | Successfully received certificate.
swag  | Certificate is saved at: /etc/letsencrypt/live/wasub.domain.tld/fullchain.pem
swag  | Key is saved at:         /etc/letsencrypt/live/wasub.domain.tld/privkey.pem
swag  | This certificate expires on 2022-12-10.
swag  | These files will be updated when the certificate renews.
swag  | NEXT STEPS:
swag  | - The certificate will need to be renewed before it expires. Certbot can automatically renew the certificate in the background, but you may need to take steps to enable that functionality. See https://certbot.org/renewal-setup for instructions.
swag  | 
swag  | - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
swag  | If you like Certbot, please consider supporting our work by:
swag  |  * Donating to ISRG / Let's Encrypt:   https://letsencrypt.org/donate
swag  |  * Donating to EFF:                    https://eff.org/donate-le
swag  | - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
swag  | New certificate generated; starting nginx
swag  | cont-init: info: /etc/cont-init.d/50-config exited 0
swag  | cont-init: info: running /etc/cont-init.d/60-renew
swag  | The cert does not expire within the next day. Letting the cron script handle the renewal attempts overnight (2:08am).
swag  | cont-init: info: /etc/cont-init.d/60-renew exited 0
swag  | cont-init: info: running /etc/cont-init.d/70-templates
swag  | cont-init: info: /etc/cont-init.d/70-templates exited 0
swag  | cont-init: info: running /etc/cont-init.d/90-custom-folders
swag  | cont-init: info: /etc/cont-init.d/90-custom-folders exited 0
swag  | cont-init: info: running /etc/cont-init.d/99-custom-files
swag  | [custom-init] no custom files found, skipping...
swag  | cont-init: info: /etc/cont-init.d/99-custom-files exited 0
swag  | s6-rc: info: service legacy-cont-init successfully started
swag  | s6-rc: info: service init-mods: starting
swag  | s6-rc: info: service init-mods successfully started
swag  | s6-rc: info: service init-mods-package-install: starting
swag  | s6-rc: info: service init-mods-package-install successfully started
swag  | s6-rc: info: service init-mods-end: starting
swag  | s6-rc: info: service init-mods-end successfully started
swag  | s6-rc: info: service init-services: starting
swag  | s6-rc: info: service init-services successfully started
swag  | s6-rc: info: service legacy-services: starting
swag  | services-up: info: copying legacy longrun cron (no readiness notification)
swag  | services-up: info: copying legacy longrun fail2ban (no readiness notification)
swag  | services-up: info: copying legacy longrun nginx (no readiness notification)
swag  | services-up: info: copying legacy longrun php-fpm (no readiness notification)
swag  | s6-rc: info: service legacy-services successfully started
swag  | s6-rc: info: service 99-ci-service-check: starting
swag  | [ls.io-init] done.
swag  | s6-rc: info: service 99-ci-service-check successfully started
swag  | Server ready
~~~

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually inspected contents of certificate, looking correct.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
https://github.com/georgeto/certbot-dns-do
https://pypi.org/project/certbot-dns-do/
