### PR TITLE
Support TLD wildcard along with nested subdomain entries

### DIFF
--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -169,27 +169,20 @@ fi
 # figuring out url only vs url & subdomains vs subdomains only
 if [ -n "$SUBDOMAINS" ]; then
     echo "SUBDOMAINS entered, processing"
-    if [ "$SUBDOMAINS" = "wildcard" ]; then
-        if [ "$ONLY_SUBDOMAINS" = true ]; then
-            export URL_REAL="-d *.${URL}"
-            echo "Wildcard cert for only the subdomains of $URL will be requested"
+    for job in $(echo "$SUBDOMAINS" | tr "," " "); do
+        if [ "$job" = "wildcard" ]; then
+            export SUBDOMAINS_REAL="$SUBDOMAINS_REAL -d *.${URL}"
         else
-            export URL_REAL="-d *.${URL} -d ${URL}"
-            echo "Wildcard cert for $URL will be requested"
-        fi
-    else
-        echo "SUBDOMAINS entered, processing"
-        for job in $(echo "$SUBDOMAINS" | tr "," " "); do
             export SUBDOMAINS_REAL="$SUBDOMAINS_REAL -d ${job}.${URL}"
-        done
-        if [ "$ONLY_SUBDOMAINS" = true ]; then
-            URL_REAL="$SUBDOMAINS_REAL"
-            echo "Only subdomains, no URL in cert"
-        else
-            URL_REAL="-d ${URL}${SUBDOMAINS_REAL}"
         fi
-        echo "Sub-domains processed are: $SUBDOMAINS_REAL"
+    done
+    if [ "$ONLY_SUBDOMAINS" = true ]; then
+        URL_REAL="$SUBDOMAINS_REAL"
+        echo "Only subdomains, no URL in cert"
+    else
+        URL_REAL="-d ${URL}${SUBDOMAINS_REAL}"
     fi
+    echo "Sub-domains processed are: $SUBDOMAINS_REAL"
 else
     echo "No subdomains defined"
     URL_REAL="-d $URL"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

<!--- Before submitting a pull request please check the following -->
------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-swag/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Updated `root/etc/cont-init.d/50-config` to support `wildcard` as part of a subdomain list vs a single static value

## Benefits of this PR and context:
* Allows for nested subdomain wildcards for services similar to JFrog Container Registry which expects a subdomain per docker repository
* ex: `docker-local.jcr.my-domain.com` supported as part of `*.jcr.my-domain.com` in addition to `*.my-domain.com` from the `wildcard` entry

## How Has This Been Tested?
* Mounted changed file to target path in my running container
* Only required change to container was updating`SUBDOMAINS=wildcard` to `SUBDOMAINS="wildcard,*.jcr"`

## Source / References:
```
URL=my-domain.com
SUBDOMAINS="wildcard,*.jcr"
EXTRA_DOMAINS=
ONLY_SUBDOMAINS=false
VALIDATION=dns
CERTPROVIDER=
DNSPLUGIN=cloudflare
EMAIL=dude@my-domain.com
STAGING=

Using Let's Encrypt as the cert provider
SUBDOMAINS entered, processing
SUBDOMAINS entered, processing
Sub-domains processed are:  -d *.my-domain.com -d *.jcr.my-domain.com
E-mail address entered: dude@my-domain.com
dns validation via cloudflare plugin is selected
Generating new certificate
Saving debug log to /var/log/letsencrypt/letsencrypt.log
Requesting a certificate for my-domain.com and 2 more domains
Waiting 10 seconds for DNS changes to propagate

Successfully received certificate.
Certificate is saved at: /etc/letsencrypt/live/my-domain.com/fullchain.pem
Key is saved at:         /etc/letsencrypt/live/my-domain.com/privkey.pem
This certificate expires on 2022-12-17.
These files will be updated when the certificate renews.