### PR TITLE
Use --dns-duckdns-no-txt-restore flag

### DIFF
--- a/root/etc/cont-init.d/50-certbot
+++ b/root/etc/cont-init.d/50-certbot
@@ -158,10 +158,13 @@ if [ "$VALIDATION" = "dns" ]; then
     elif [[ "$DNSPLUGIN" =~ ^(azure|gandi)$ ]]; then
         if [ -n "$PROPAGATION" ]; then echo "${DNSPLUGIN} dns plugin does not support setting propagation time"; fi
         PREFCHAL="-a dns-${DNSPLUGIN} --dns-${DNSPLUGIN}-credentials /config/dns-conf/${DNSPLUGIN}.ini"
+    elif [[ "$DNSPLUGIN" =~ ^(duckdns)$ ]]; then
+        if [ -n "$PROPAGATION" ]; then PROPAGATIONPARAM="--dns-${DNSPLUGIN}-propagation-seconds ${PROPAGATION}"; fi
+        PREFCHAL="-a dns-${DNSPLUGIN} --dns-${DNSPLUGIN}-credentials /config/dns-conf/${DNSPLUGIN}.ini --dns-duckdns-no-txt-restore ${PROPAGATIONPARAM}"
     elif [[ "$DNSPLUGIN" =~ ^(google)$ ]]; then
         if [ -n "$PROPAGATION" ]; then PROPAGATIONPARAM="--dns-${DNSPLUGIN}-propagation-seconds ${PROPAGATION}"; fi
         PREFCHAL="--dns-${DNSPLUGIN} --dns-${DNSPLUGIN}-credentials /config/dns-conf/${DNSPLUGIN}.json ${PROPAGATIONPARAM}"
-    elif [[ "$DNSPLUGIN" =~ ^(acmedns|aliyun|cpanel|desec|dnspod|do|domeneshop|duckdns|dynu|godaddy|he|hetzner|infomaniak|inwx|ionos|loopia|netcup|njalla|porkbun|transip|vultr)$ ]]; then
+    elif [[ "$DNSPLUGIN" =~ ^(acmedns|aliyun|cpanel|desec|dnspod|do|domeneshop|dynu|godaddy|he|hetzner|infomaniak|inwx|ionos|loopia|netcup|njalla|porkbun|transip|vultr)$ ]]; then
         if [ -n "$PROPAGATION" ]; then PROPAGATIONPARAM="--dns-${DNSPLUGIN}-propagation-seconds ${PROPAGATION}"; fi
         PREFCHAL="-a dns-${DNSPLUGIN} --dns-${DNSPLUGIN}-credentials /config/dns-conf/${DNSPLUGIN}.ini ${PROPAGATIONPARAM}"
     elif [[ "$DNSPLUGIN" =~ ^(standalone)$ ]]; then


### PR DESCRIPTION
Should allow local DNS records with DuckDNS

Potentially solves https://github.com/linuxserver/docker-swag/issues/292 and https://github.com/linuxserver/docker-swag/issues/281

Needs testing!