### PR TITLE
Relocate live cert symlink

### DIFF
--- a/root/etc/cont-init.d/50-certbot
+++ b/root/etc/cont-init.d/50-certbot
@@ -194,10 +194,6 @@ if [ "$ONLY_SUBDOMAINS" = "true" ] && [ ! "$SUBDOMAINS" = "wildcard" ]; then
 else
     ln -s ../etc/letsencrypt/live/"$URL" /config/keys/letsencrypt
 fi
-rm -rf /config/keys/cert.crt
-ln -s ./letsencrypt/fullchain.pem /config/keys/cert.crt
-rm -rf /config/keys/cert.key
-ln -s ./letsencrypt/privkey.pem /config/keys/cert.key
 
 # checking for changes in cert variables, revoking certs if necessary
 if [ ! "$URL" = "$ORIGURL" ] || [ ! "$SUBDOMAINS" = "$ORIGSUBDOMAINS" ] || [ ! "$ONLY_SUBDOMAINS" = "$ORIGONLY_SUBDOMAINS" ] || [ ! "$EXTRA_DOMAINS" = "$ORIGEXTRA_DOMAINS" ] || [ ! "$VALIDATION" = "$ORIGVALIDATION" ] || [ ! "$DNSPLUGIN" = "$ORIGDNSPLUGIN" ] || [ ! "$PROPAGATION" = "$ORIGPROPAGATION" ] || [ ! "$STAGING" = "$ORIGSTAGING" ] || [ ! "$CERTPROVIDER" = "$ORIGCERTPROVIDER" ]; then
@@ -275,4 +271,12 @@ if [ ! -f "/config/keys/letsencrypt/fullchain.pem" ]; then
     echo "New certificate generated; starting nginx"
 else
     echo "Certificate exists; parameters unchanged; starting nginx"
+fi
+
+# if certbot generated key exists, remove self-signed cert and replace it with symlink to live cert
+if [ -d /config/keys/letsencrypt ]; then
+    rm -rf /config/keys/cert.crt
+    ln -s ./letsencrypt/fullchain.pem /config/keys/cert.crt
+    rm -rf /config/keys/cert.key
+    ln -s ./letsencrypt/privkey.pem /config/keys/cert.key
 fi


### PR DESCRIPTION
In addition to https://github.com/linuxserver/docker-baseimage-alpine-nginx/pull/115

I believe removing the self signed cert files and replacing them with symlinks before certbot successfully generates live cert files is causing `15-keygen` in the base to fail because the `if` condition thinks the files don't exist (symlinks do, but the files at the destination of the symlinks do not) so it tries to run `openssl` which fails because it can't write out files to the specified locations because there are symlinks in the way.

The above linked PR to the base should resolve the issue, but this change would also only remove the self signed cert files and replace them with symlinks if the live certs have been successfully generated.

A common case where this makes sense to have a safety check would be when the user wants to use `dns` validation. The initial run is likely to fail because it will place new copies of the `dns-conf` files and the user will need to fill in their information to the `dns-conf` for their chosen provider and restart the container. The current behavior will leave broken symlinks, potentially causing errors when the container restarts. This new/modified behavior should avoid that.