### PR TITLE
Add abc crontab

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-crontabs-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-crontabs-config/run
@@ -13,5 +13,18 @@ if [[ ! -f /config/crontabs/root ]]; then
     cp /etc/crontabs/root /config/crontabs/
 fi
 
+# if abc crontabs do not exist in config
+# copy abc crontab from system
+if [[ ! -f /config/crontabs/abc ]] && crontab -l -u abc; then
+    crontab -l -u abc >/config/crontabs/abc
+fi
+
+# if abc crontabs still do not exist in config (were not copied from system)
+# copy abc crontab from included defaults
+if [[ ! -f /config/crontabs/abc ]]; then
+    cp /etc/crontabs/abc /config/crontabs/
+fi
+
 # import user crontabs
 crontab -u root /config/crontabs/root
+crontab -u abc /config/crontabs/abc


### PR DESCRIPTION
Ref: https://discord.com/channels/354974912613449730/1067391319196053514

Previously the whole `/config/crontabs` folder was copied into `/etc/crontabs`, but we only provided a `root` file by default. Users could add any file name there (not just `root` or `abc`) and it would copy in.

That behavior was changed in https://github.com/linuxserver/docker-swag/pull/315 but the intention wasn't to prevent using cron as `abc`.

It's probably best if we only support `root` and `abc` out of the box.