### PR TITLE
Add porkbun support back in

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -125,6 +125,7 @@ RUN \
     certbot-dns-njalla \
     certbot-dns-nsone \
     certbot-dns-ovh \
+    certbot-dns-porkbun \
     certbot-dns-rfc2136 \
     certbot-dns-route53 \
     certbot-dns-sakuracloud \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -125,6 +125,7 @@ RUN \
     certbot-dns-njalla \
     certbot-dns-nsone \
     certbot-dns-ovh \
+    certbot-dns-porkbun \
     certbot-dns-rfc2136 \
     certbot-dns-route53 \
     certbot-dns-sakuracloud \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -125,6 +125,7 @@ RUN \
     certbot-dns-njalla \
     certbot-dns-nsone \
     certbot-dns-ovh \
+    certbot-dns-porkbun \
     certbot-dns-rfc2136 \
     certbot-dns-route53 \
     certbot-dns-sakuracloud \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -154,6 +154,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "06.02.23:", desc: "Add porkbun support back in." }
   - { date: "21.01.23:", desc: "Unpin certbot version (allow certbot 2.x). !!BREAKING CHANGE!! We are temporarily removing the certbot porkbun plugin until a new version is released that is compatible with certbot 2.x." }
   - { date: "20.01.23:", desc: "Rebase to alpine 3.17 with php8.1." }
   - { date: "16.01.23:", desc: "Remove nchan module because it keeps causing crashes." }

--- a/root/etc/s6-overlay/s6-rc.d/init-certbot-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-certbot-config/run
@@ -24,7 +24,7 @@ for i in "${SANED_VARS[@]}"; do
 done
 
 # check to make sure DNSPLUGIN is selected if dns validation is used
-if [[ "${VALIDATION}" = "dns" ]] && [[ ! "${DNSPLUGIN}" =~ ^(acmedns|aliyun|azure|cloudflare|cpanel|desec|digitalocean|directadmin|dnsimple|dnsmadeeasy|dnspod|do|domeneshop|duckdns|dynu|gandi|gehirn|godaddy|google|he|hetzner|infomaniak|inwx|ionos|linode|loopia|luadns|netcup|njalla|nsone|ovh|rfc2136|route53|sakuracloud|standalone|transip|vultr)$ ]]; then
+if [[ "${VALIDATION}" = "dns" ]] && [[ ! "${DNSPLUGIN}" =~ ^(acmedns|aliyun|azure|cloudflare|cpanel|desec|digitalocean|directadmin|dnsimple|dnsmadeeasy|dnspod|do|domeneshop|duckdns|dynu|gandi|gehirn|godaddy|google|he|hetzner|infomaniak|inwx|ionos|linode|loopia|luadns|netcup|njalla|nsone|ovh|porkbun|rfc2136|route53|sakuracloud|standalone|transip|vultr)$ ]]; then
     echo "Please set the DNSPLUGIN variable to a valid plugin name. See docker info for more details."
     sleep infinity
 fi


### PR DESCRIPTION
Porkbun was removed in https://github.com/linuxserver/docker-swag/pull/308 to allow upgrading certbot to 2.x. The plugin should now support certbot 2.x.

This closes https://github.com/linuxserver/docker-swag/issues/325