### PR TITLE
Comment Default Configs

### DIFF
--- a/root/defaults/dns-conf/route53.ini
+++ b/root/defaults/dns-conf/route53.ini
@@ -1,5 +1,5 @@
 # Instructions: https://github.com/certbot/certbot/blob/master/certbot-dns-route53/certbot_dns_route53/__init__.py#L18
 # Replace with your values
 [default]
-aws_access_key_id=AKIAIOSFODNN7EXAMPLE
-aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+; aws_access_key_id=AKIAIOSFODNN7EXAMPLE
+; aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY


### PR DESCRIPTION
Comments out credentials for AWS Route53

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-swag/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Reason for change - Explicitly providing incorrect credentials to the aws libraries will always result in an unauthorized request. When running on aws, providing no credentials allows the libraries to obtain temporary credentials from aws IMDS when an ec2 instance has assumed a role. 

Commenting these lines out allows the libraries (boto3 in the case of certbot) to function as intended, while still indicating the format of these variables to any reader of this file. 

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Benefits users running swag on aws services who want to use dns verification with route53. It negatively impacts 0 users. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested on an ec2 instance. Did not need to provide aws credentials after this was commenting out, due to instance having assumed role. 
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

