### PR TITLE
Silence allowipv6 warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -160,7 +160,7 @@ RUN \
   mv /etc/fail2ban/action.d /defaults/fail2ban/ && \
   mv /etc/fail2ban/filter.d /defaults/fail2ban/ && \
   echo "**** define allowipv6 to silence warning ****" && \
-  sed -i 's/#allowipv6 = auto/allowipv6 = auto/g' /etc/fail2ban.conf && \
+  sed -i 's/#allowipv6 = auto/allowipv6 = auto/g' /etc/fail2ban/fail2ban.conf && \
   echo "**** copy proxy confs to /defaults ****" && \
   mkdir -p \
     /defaults/nginx/proxy-confs && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -159,6 +159,8 @@ RUN \
   mkdir -p /defaults/fail2ban && \
   mv /etc/fail2ban/action.d /defaults/fail2ban/ && \
   mv /etc/fail2ban/filter.d /defaults/fail2ban/ && \
+  echo "**** define allowipv6 to silence warning ****" && \
+  sed -i 's/#allowipv6 = auto/allowipv6 = auto/g' /etc/fail2ban.conf && \
   echo "**** copy proxy confs to /defaults ****" && \
   mkdir -p \
     /defaults/nginx/proxy-confs && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -160,7 +160,7 @@ RUN \
   mv /etc/fail2ban/action.d /defaults/fail2ban/ && \
   mv /etc/fail2ban/filter.d /defaults/fail2ban/ && \
   echo "**** define allowipv6 to silence warning ****" && \
-  sed -i 's/#allowipv6 = auto/allowipv6 = auto/g' /etc/fail2ban.conf && \
+  sed -i 's/#allowipv6 = auto/allowipv6 = auto/g' /etc/fail2ban/fail2ban.conf && \
   echo "**** copy proxy confs to /defaults ****" && \
   mkdir -p \
     /defaults/nginx/proxy-confs && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -159,6 +159,8 @@ RUN \
   mkdir -p /defaults/fail2ban && \
   mv /etc/fail2ban/action.d /defaults/fail2ban/ && \
   mv /etc/fail2ban/filter.d /defaults/fail2ban/ && \
+  echo "**** define allowipv6 to silence warning ****" && \
+  sed -i 's/#allowipv6 = auto/allowipv6 = auto/g' /etc/fail2ban.conf && \
   echo "**** copy proxy confs to /defaults ****" && \
   mkdir -p \
     /defaults/nginx/proxy-confs && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -160,7 +160,7 @@ RUN \
   mv /etc/fail2ban/action.d /defaults/fail2ban/ && \
   mv /etc/fail2ban/filter.d /defaults/fail2ban/ && \
   echo "**** define allowipv6 to silence warning ****" && \
-  sed -i 's/#allowipv6 = auto/allowipv6 = auto/g' /etc/fail2ban.conf && \
+  sed -i 's/#allowipv6 = auto/allowipv6 = auto/g' /etc/fail2ban/fail2ban.conf && \
   echo "**** copy proxy confs to /defaults ****" && \
   mkdir -p \
     /defaults/nginx/proxy-confs && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -159,6 +159,8 @@ RUN \
   mkdir -p /defaults/fail2ban && \
   mv /etc/fail2ban/action.d /defaults/fail2ban/ && \
   mv /etc/fail2ban/filter.d /defaults/fail2ban/ && \
+  echo "**** define allowipv6 to silence warning ****" && \
+  sed -i 's/#allowipv6 = auto/allowipv6 = auto/g' /etc/fail2ban.conf && \
   echo "**** copy proxy confs to /defaults ****" && \
   mkdir -p \
     /defaults/nginx/proxy-confs && \


### PR DESCRIPTION
resolves https://github.com/linuxserver/docker-swag/issues/335
I've been closing these issues and ignoring them in discord as they'rea benign warning, but it doesn't seem like it's much effort to resolve.

currently logs will show `2023-03-29 08:48:35,232 fail2ban.configreader   [515]: WARNING 'allowipv6' not defined in 'Definition'. Using default one: 'auto'`

this is because by default the line is commented out in the shipped fail2ban. this just sets it to exactly what it's defaulting to. this should eliminate the warning without any change in functionality.