### PR TITLE
route53 no longer supports propagation

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-certbot-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-certbot-config/run
@@ -274,7 +274,7 @@ if [[ "${VALIDATION}" = "dns" ]]; then
         DNSCREDENTIALSPARAM=""
     fi
     # plugins that don't support setting propagation
-    if [[ "${DNSPLUGIN}" =~ ^(azure|gandi|standalone)$ ]]; then
+    if [[ "${DNSPLUGIN}" =~ ^(azure|gandi|route53|standalone)$ ]]; then
         if [[ -n "${PROPAGATION}" ]]; then echo "${DNSPLUGIN} dns plugin does not support setting propagation time"; fi
         PROPAGATIONPARAM=""
     fi


### PR DESCRIPTION
Released in certbot 2.5.0 https://github.com/certbot/certbot/blob/df85c25da824ffd284a0d0b83ff4d9e2f60f4c82/certbot/CHANGELOG.md#changed
