### PR TITLE
Implements custom ACME servers

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -50,8 +50,10 @@ cap_add_param_vars:
 opt_param_usage_include_env: true
 opt_param_env_vars:
   - { env_var: "SUBDOMAINS", env_value: "www,", desc: "Subdomains you'd like the cert to cover (comma separated, no spaces) ie. `www,ftp,cloud`. For a wildcard cert, set this *exactly* to `wildcard` (wildcard cert is available via `dns` validation only)" }
-  - { env_var: "CERTPROVIDER", env_value: "", desc: "Optionally define the cert provider. Set to `zerossl` for ZeroSSL certs (requires existing [ZeroSSL account](https://app.zerossl.com/signup) and the e-mail address entered in `EMAIL` env var). Otherwise defaults to Let's Encrypt." }
+  - { env_var: "CERTPROVIDER", env_value: "", desc: "Optionally define the cert provider. Set to `zerossl` for ZeroSSL certs (requires existing [ZeroSSL account](https://app.zerossl.com/signup) and the e-mail address entered in `EMAIL` env var). Set to `custom` to use a custom ACME server. Defaults to Let's Encrypt unless `ACMESERVER` is set. " }
   - { env_var: "DNSPLUGIN", env_value: "cloudflare", desc: "Required if `VALIDATION` is set to `dns`. Options are `acmedns`, `aliyun`, `azure`, `cloudflare`, `cpanel`, `desec`, `digitalocean`, `directadmin`, `dnsimple`, `dnsmadeeasy`, `dnspod`, `do`, `domeneshop`, `duckdns`, `dynu`, `gandi`, `gehirn`, `godaddy`, `google`, `google-domains`, `he`, `hetzner`, `infomaniak`, `inwx`, `ionos`, `linode`, `loopia`, `luadns`, `netcup`, `njalla`, `nsone`, `ovh`, `porkbun`, `rfc2136`, `route53`, `sakuracloud`, `standalone`, `transip`, and `vultr`. Also need to enter the credentials into the corresponding ini (or json for some plugins) file under `/config/dns-conf`." }
+  - { env_var: "ACMESERVER", env_value: "", desc: "The URL of a custom ACME server to use." }
+  - { env_var: "ACMECABUNDLE", env_value: "", desc: "A base64-encoded PEM file containing a CA bundle to trust, for use with an internal ACME CA. Required for a custom ACME CA." }
   - { env_var: "PROPAGATION", env_value: "", desc: "Optionally override (in seconds) the default propagation time for the dns plugins." }
   - { env_var: "EMAIL", env_value: "", desc: "Optional e-mail address used for cert expiration notifications (Required for ZeroSSL)." }
   - { env_var: "ONLY_SUBDOMAINS", env_value: "false", desc: "If you wish to get certs only for certain subdomains, but not the main domain (main domain may be hosted on another machine and cannot be validated), set this to `true`" }
@@ -154,6 +156,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "21.05.23:", desc: "Allow custom ACME servers. Supply URL and CA bundle" }
   - { date: "27.04.23:", desc: "[Existing users should update:](https://github.com/linuxserver/docker-swag/blob/master/README.md#updating-configs) authelia-location.conf, authelia-server.conf, authentik-location.conf, authentik-server.conf - Simplify auth configs and fix Set-Cookie header bug." }
   - { date: "13.04.23:", desc: "[Existing users should update:](https://github.com/linuxserver/docker-swag/blob/master/README.md#updating-configs) nginx.conf, authelia-location.conf, authentik-location.conf, and site-confs/default.conf - Move ssl.conf include to default.conf. Remove Authorization headers in authelia. Sort proxy_set_header in authelia and authentik." }
   - { date: "25.03.23:", desc: "Fix renewal post hook." }

--- a/root/app/le-renew.sh
+++ b/root/app/le-renew.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
+if [[ -f "/config/cabundle.pem" ]]; then
+	export REQUESTS_CA_BUNDLE="/config/cabundle.pem"
+fi
+
 echo "<------------------------------------------------->"
 echo
 echo "<------------------------------------------------->"

--- a/root/etc/s6-overlay/s6-rc.d/init-certbot-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-certbot-config/run
@@ -12,6 +12,8 @@ EXTRA_DOMAINS=${EXTRA_DOMAINS}\\n\
 ONLY_SUBDOMAINS=${ONLY_SUBDOMAINS}\\n\
 VALIDATION=${VALIDATION}\\n\
 CERTPROVIDER=${CERTPROVIDER}\\n\
+ACMESERVER=${ACMESERVER}\\n\
+ACMECABUNDLE=${ACMECABUNDLE}\\n\
 DNSPLUGIN=${DNSPLUGIN}\\n\
 EMAIL=${EMAIL}\\n\
 STAGING=${STAGING}\\n"
@@ -48,7 +50,7 @@ if [[ -f "/config/donoteditthisfile.conf" ]]; then
     mv /config/donoteditthisfile.conf /config/.donoteditthisfile.conf
 fi
 if [[ ! -f "/config/.donoteditthisfile.conf" ]]; then
-    echo -e "ORIGURL=\"${URL}\" ORIGSUBDOMAINS=\"${SUBDOMAINS}\" ORIGONLY_SUBDOMAINS=\"${ONLY_SUBDOMAINS}\" ORIGEXTRA_DOMAINS=\"${EXTRA_DOMAINS}\" ORIGVALIDATION=\"${VALIDATION}\" ORIGDNSPLUGIN=\"${DNSPLUGIN}\" ORIGPROPAGATION=\"${PROPAGATION}\" ORIGSTAGING=\"${STAGING}\" ORIGCERTPROVIDER=\"${CERTPROVIDER}\" ORIGEMAIL=\"${EMAIL}\"" >/config/.donoteditthisfile.conf
+    echo -e "ORIGURL=\"${URL}\" ORIGSUBDOMAINS=\"${SUBDOMAINS}\" ORIGONLY_SUBDOMAINS=\"${ONLY_SUBDOMAINS}\" ORIGEXTRA_DOMAINS=\"${EXTRA_DOMAINS}\" ORIGVALIDATION=\"${VALIDATION}\" ORIGDNSPLUGIN=\"${DNSPLUGIN}\" ORIGPROPAGATION=\"${PROPAGATION}\" ORIGSTAGING=\"${STAGING}\" ORIGCERTPROVIDER=\"${CERTPROVIDER}\"  ORIGACMESERVER=\"$ACMESERVER\" ORIGACMECABUNDLE=\"$ACMECABUNDLE\" ORIGEMAIL=\"${EMAIL}\"" >/config/.donoteditthisfile.conf
     echo "Created .donoteditthisfile.conf"
 fi
 
@@ -177,10 +179,10 @@ if [[ ! "${URL}" = "${ORIGURL}" ]] ||
 fi
 
 # saving new variables
-echo -e "ORIGURL=\"${URL}\" ORIGSUBDOMAINS=\"${SUBDOMAINS}\" ORIGONLY_SUBDOMAINS=\"${ONLY_SUBDOMAINS}\" ORIGEXTRA_DOMAINS=\"${EXTRA_DOMAINS}\" ORIGVALIDATION=\"${VALIDATION}\" ORIGDNSPLUGIN=\"${DNSPLUGIN}\" ORIGPROPAGATION=\"${PROPAGATION}\" ORIGSTAGING=\"${STAGING}\" ORIGCERTPROVIDER=\"${CERTPROVIDER}\" ORIGEMAIL=\"${EMAIL}\"" >/config/.donoteditthisfile.conf
+echo -e "ORIGURL=\"${URL}\" ORIGSUBDOMAINS=\"${SUBDOMAINS}\" ORIGONLY_SUBDOMAINS=\"${ONLY_SUBDOMAINS}\" ORIGEXTRA_DOMAINS=\"${EXTRA_DOMAINS}\" ORIGVALIDATION=\"${VALIDATION}\" ORIGDNSPLUGIN=\"${DNSPLUGIN}\" ORIGPROPAGATION=\"${PROPAGATION}\" ORIGSTAGING=\"${STAGING}\" ORIGCERTPROVIDER=\"${CERTPROVIDER}\" ORIGACMESERVER=\"$ACMESERVER\" ORIGACMECABUNDLE=\"$ACMECABUNDLE\" ORIGEMAIL=\"${EMAIL}\"" >/config/.donoteditthisfile.conf
 
 # Check if the cert is using the old LE root cert, revoke and regen if necessary
-if [[ -f "/config/keys/letsencrypt/chain.pem" ]] && { [[ "${CERTPROVIDER}" == "letsencrypt" ]] || [[ "${CERTPROVIDER}" == "" ]]; } && [[ "${STAGING}" != "true" ]] && ! openssl x509 -in /config/keys/letsencrypt/chain.pem -noout -issuer | grep -q "ISRG Root X"; then
+if [[ -f "/config/keys/letsencrypt/chain.pem" ]] && { [[ "${CERTPROVIDER}" == "letsencrypt" ]] || ([[ "${CERTPROVIDER}" == "" ]] && [[ -z "$ACMECABUNDLE" ]]); } && [[ "${STAGING}" != "true" ]] && ! openssl x509 -in /config/keys/letsencrypt/chain.pem -noout -issuer | grep -q "ISRG Root X"; then
     echo "The cert seems to be using the old LE root cert, which is no longer valid. Deleting and revoking."
     REV_ACMESERVER="https://acme-v02.api.letsencrypt.org/directory"
     if [[ -f /config/etc/letsencrypt/live/"${ORIGDOMAIN}"/fullchain.pem ]]; then
@@ -193,11 +195,23 @@ fi
 if [[ "${CERTPROVIDER}" = "zerossl" ]] && [[ "${STAGING}" = "true" ]]; then
     echo "ZeroSSL does not support staging mode, ignoring STAGING variable"
 fi
+if [[ "${CERTPROVIDER}" = "custom" ]] && [[ "${STAGING}" = "true" ]]; then
+    echo "Custom ACME does not support staging mode, ignoring STAGING variable"
+fi
 if [[ "${CERTPROVIDER}" = "zerossl" ]] && [[ -n "${EMAIL}" ]]; then
     echo "ZeroSSL is selected as the cert provider, registering cert with ${EMAIL}"
     ACMESERVER="https://acme.zerossl.com/v2/DV90"
 elif [[ "${CERTPROVIDER}" = "zerossl" ]] && [[ -z "${EMAIL}" ]]; then
     echo "ZeroSSL is selected as the cert provider, but the e-mail address has not been entered. Please visit https://zerossl.com, register a new account and set the account e-mail address in the EMAIL environment variable"
+    sleep infinity
+elif [[ "${CERTPROVIDER}" = "custom" ]] && [[ -n "${EMAIL}" ]]; then
+    echo "Using $ACMESERVER as the cert provider; registering cert with $EMAIL"
+    if [ -n "$ACMECABUNDLE" ]; then
+        echo "$ACMECABUNDLE" | base64 -d - > /config/cabundle.pem
+        export REQUESTS_CA_BUNDLE="/config/cabundle.pem"
+    fi
+elif [[ "${CERTPROVIDER}" = "custom" ]] && [[ -z "${EMAIL}" ]]; then
+    echo "A custom ACME server is selected as the cert provider, but the e-email address has not been entered."
     sleep infinity
 elif [[ "${STAGING}" = "true" ]]; then
     echo "NOTICE: Staging is active"


### PR DESCRIPTION
Code mostly taken from: https://github.com/tashian/docker-swag/commit/564e0d8175624dd8f5e4c648f0ff36ecb93de7d1

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-swag/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Implements custom ACME server. This PR introduces 2 environment variables that will allow you to point swag towards a custom ACME server (as opposed to Let's Encrypt or ZeroSSL) and to trust the custom ACME's root certificate.  

## Benefits of this PR and context:
Swag's ACME process is designed for issuing SSL certs to publicly available domains. With this PR, users with internal/private domains can issue SSL certs by pointing swag towards their own ACME servers. This functionality is impossible with Lets Encrypt or ZeroSSL since internal domains cannot be resolved or reached outside of their private networks. 

## How Has This Been Tested?
I setup a Step ACME server following the guide here[1]. Then I setup a swag docker instance on a separate device with my changes to the code. I also tested running a portainer docker instance via an nginx subdomain proxy to make sure SSL worked for both the my internal domain and internal subdomain.


## Source / References:
1. https://smallstep.com/blog/build-a-tiny-ca-with-raspberry-pi-yubikey/
2. Closes #186 