### PR TITLE
Fix "unrecognized arguments" issue in DirectAdmin DNS plugin

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -153,6 +153,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "01.10.23:", desc: "Fix \"unrecognized arguments\" issue in DirectAdmin DNS plugin." }
   - { date: "28.08.23:", desc: "Add Namecheap DNS plugin." }
   - { date: "12.08.23:", desc: "Add FreeDNS plugin. Detect certbot DNS authenticators using CLI." }
   - { date: "07.08.23:", desc: "Add Bunny DNS Configuration." }

--- a/root/etc/s6-overlay/s6-rc.d/init-certbot-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-certbot-config/run
@@ -304,7 +304,7 @@ if [[ "${VALIDATION}" = "dns" ]]; then
         sed -i "/^dns-${DNSPLUGIN}-propagation-seconds\b/d" /config/etc/letsencrypt/cli.ini
     fi
     # plugins that use old parameter naming convention
-    if [[ "${DNSPLUGIN}" =~ ^(cpanel|directadmin)$ ]]; then
+    if [[ "${DNSPLUGIN}" =~ ^(cpanel)$ ]]; then
         sed -i "/^dns-${DNSPLUGIN}-credentials\b/d" /config/etc/letsencrypt/cli.ini
         sed -i "/^dns-${DNSPLUGIN}-propagation-seconds\b/d" /config/etc/letsencrypt/cli.ini
         set_ini_value "authenticator" "${DNSPLUGIN}" /config/etc/letsencrypt/cli.ini


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-swag/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Since v1.0.3 of the certbot-dns-directadmin plugin the parameter prefix was changed to `dns-directadmin-` in stead of `directadmin-`.
This PR addresses this change as the current logic is broken.
Example:
```
root@37e5913fddc8:/# certbot plugins --authenticators
usage:
  certbot [SUBCOMMAND] [options] [-d DOMAIN] [-d DOMAIN] ...

Certbot can obtain and install HTTPS/TLS/SSL certificates.  By default,
it will attempt to use a webserver both for obtaining and installing the
certificate.
certbot: error: unrecognized arguments: --directadmin-credentials=/config/dns-conf/directadmin.ini
```

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Closes #404.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Built the container, pushed to Docker Hub (simonlepla/swag:directadmin-fix) and tested it on my setup.
Had to manually remove `/config/etc/letsencrypt/cli.ini` (as this was mounted/persisted on disk) in order for it to be regenerated with the new parameters.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
