### PR TITLE
support for authelia 4.38+

### DIFF
--- a/root/defaults/nginx/authelia-location.conf.sample
+++ b/root/defaults/nginx/authelia-location.conf.sample
@@ -2,7 +2,7 @@
 # Make sure that your authelia container is in the same user defined bridge network and is named authelia
 # Rename /config/nginx/proxy-confs/authelia.subdomain.conf.sample to /config/nginx/proxy-confs/authelia.subdomain.conf
 # For authelia 4.37 and below, make sure that the authelia configuration.yml has 'path: "authelia"' defined
-# For authelia 4.38 and above, make sure that the authelia configuration.yml has 'address: "tcp://0.0.0.0:9091/authelia"' defined
+# For authelia 4.38 and above, make sure that the authelia configuration.yml has 'address: "tcp://:9091/authelia"' defined
 
 ## Send a subrequest to Authelia to verify if the user is authenticated and has permission to access the resource
 ## For authelia 4.37 and below, use the following line

--- a/root/defaults/nginx/authelia-location.conf.sample
+++ b/root/defaults/nginx/authelia-location.conf.sample
@@ -1,10 +1,15 @@
-## Version 2023/04/27 - Changelog: https://github.com/linuxserver/docker-swag/commits/master/root/defaults/nginx/authelia-location.conf.sample
+## Version 2024/03/14 - Changelog: https://github.com/linuxserver/docker-swag/commits/master/root/defaults/nginx/authelia-location.conf.sample
 # Make sure that your authelia container is in the same user defined bridge network and is named authelia
 # Rename /config/nginx/proxy-confs/authelia.subdomain.conf.sample to /config/nginx/proxy-confs/authelia.subdomain.conf
-# Make sure that the authelia configuration.yml has 'path: "authelia"' defined
+# For authelia 4.37 and below, make sure that the authelia configuration.yml has 'path: "authelia"' defined
+# For authelia 4.38 and above, make sure that the authelia configuration.yml has 'address: "tcp://0.0.0.0:9091/authelia"' defined
 
 ## Send a subrequest to Authelia to verify if the user is authenticated and has permission to access the resource
-auth_request /authelia/api/verify;
+## For authelia 4.37 and below, use the following line
+# auth_request /authelia/api/verify;
+## For authelia 4.38 and above, use the following line
+auth_request /authelia/api/authz/auth-request;
+
 ## If the subreqest returns 200 pass to the backend, if the subrequest returns 401 redirect to the portal
 error_page 401 = @authelia_proxy_signin;
 

--- a/root/defaults/nginx/authelia-server.conf.sample
+++ b/root/defaults/nginx/authelia-server.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/04/27 - Changelog: https://github.com/linuxserver/docker-swag/commits/master/root/defaults/nginx/authelia-server.conf.sample
+## Version 2024/03/14 - Changelog: https://github.com/linuxserver/docker-swag/commits/master/root/defaults/nginx/authelia-server.conf.sample
 # Make sure that your authelia container is in the same user defined bridge network and is named authelia
 # Rename /config/nginx/proxy-confs/authelia.subdomain.conf.sample to /config/nginx/proxy-confs/authelia.subdomain.conf
 # Make sure that the authelia configuration.yml has 'path: "authelia"' defined
@@ -13,7 +13,7 @@ location ^~ /authelia {
 }
 
 # location for authelia auth requests
-location = /authelia/api/verify {
+location ~ /authelia/api/(authz/auth-request|verify) {
     internal;
 
     include /config/nginx/proxy.conf;

--- a/root/defaults/nginx/authelia-server.conf.sample
+++ b/root/defaults/nginx/authelia-server.conf.sample
@@ -1,7 +1,8 @@
 ## Version 2024/03/14 - Changelog: https://github.com/linuxserver/docker-swag/commits/master/root/defaults/nginx/authelia-server.conf.sample
 # Make sure that your authelia container is in the same user defined bridge network and is named authelia
 # Rename /config/nginx/proxy-confs/authelia.subdomain.conf.sample to /config/nginx/proxy-confs/authelia.subdomain.conf
-# Make sure that the authelia configuration.yml has 'path: "authelia"' defined
+# For authelia 4.37 and below, make sure that the authelia configuration.yml has 'path: "authelia"' defined
+# For authelia 4.38 and above, make sure that the authelia configuration.yml has 'address: "tcp://:9091/authelia"' defined
 
 # location for authelia subfolder requests
 location ^~ /authelia {

--- a/root/defaults/nginx/authentik-location.conf.sample
+++ b/root/defaults/nginx/authentik-location.conf.sample
@@ -4,6 +4,7 @@
 
 ## Send a subrequest to Authentik to verify if the user is authenticated and has permission to access the resource
 auth_request /outpost.goauthentik.io/auth/nginx;
+
 ## If the subreqest returns 200 pass to the backend, if the subrequest returns 401 redirect to the portal
 error_page 401 = @goauthentik_proxy_signin;
 


### PR DESCRIPTION
supersedes https://github.com/linuxserver/docker-swag/pull/464

https://github.com/linuxserver/reverse-proxy-confs/pull/656 is not needed.