### PR TITLE
Create internal.conf

### DIFF
--- a/root/defaults/nginx/internal.conf
+++ b/root/defaults/nginx/internal.conf
@@ -1,0 +1,7 @@
+# List of private IP addresses to ensure all traffic is local.
+## Remove or comment any out to be even more restrictive.
+allow 10.0.0.0/8;
+allow 172.16.0.0/12;
+allow 192.168.0.0/16;
+allow 100.64.0.0/16; # Tailcale's default IP range
+deny all;


### PR DESCRIPTION
Add a single conf file that can be used in proxy-confs via "include /config/nginx/internal.conf" for a single point of management for allowed IPs.

EDIT: Completed template.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-swag/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Added an internal.conf that specifies common internal IP ranges and tailscale's default range. Blocks access from all other IPs with a 403.

## Benefits of this PR and context:
Provides a single place to specify approved IP ranges that may be used across multiple proxy-confs via "include /config/nginx/internal.conf".

## How Has This Been Tested?
Yes, had the same snippet within the file in my dashboard.subdomain.conf. Removed that in exchange for "include /config/nginx/internal.conf" and access is still restricted to local IPs.


## Source / References:
N/A