### PR TITLE
Reverting change in d377c95 to fix letsencrypt symlink

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -200,6 +200,7 @@ init_diagram: |
   "swag:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "07.01.25:", desc: "Reverting symlink change made preventing Letsencrypt from finding certificates."}
   - {date: "17.12.24:", desc: "Rebase to Alpine 3.21."}
   - {date: "21.10.24:", desc: "Fix naming issue with Dynu plugin. If you are using Dynu, please make sure your credentials are set in /config/dns-conf/dynu.ini and your DNSPLUGIN variable is set to dynu (not dynudns)."}
   - {date: "30.08.24:", desc: "Fix zerossl cert revocation."}

--- a/root/etc/s6-overlay/s6-rc.d/init-swag-folders/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-swag-folders/run
@@ -10,3 +10,5 @@ mkdir -p \
     /run/fail2ban \
     /tmp/letsencrypt
 
+rm -rf /etc/letsencrypt
+ln -s /config/etc/letsencrypt /etc/letsencrypt


### PR DESCRIPTION
Reverting change made in commit d377c95 that stopped symlinking the certbot config directory to /etc/letsencrypt

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-swag/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->

There was a change in the commit `d377c95` that pointed Certbot to `--config-dir` to `/config/etc/letsencrypt` which combined with the removal of the symlink creation in `root/etc/s6-overlay/s6-rc.d/init-swag-folders/run` for `/config/etc/letsencrypt` and `/etc/letsencrypt`, caused the break.

Additional changes to the Certbot in this commit included  `root/etc/s6-overlay/s6-rc.d/init-certbot-config/run` which also now points multiple commands to `/config/etc/letsencrypt` vs the previously existing `/etc/letsencrypt`.

This stopped Swag from being able to start up correctly as the letsencrypt service was unable to locate any certificates. 

I may be incorrect in assuming this but keeping `/config/etc/letsencrypt` and adding back the symlink seemed like the best way forward. 

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

This is a break-fix - No github issue but a Discord one - https://discord.com/channels/354974912613449730/1325836298086518784

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


To test my fix, I made the change in `root/etc/s6-overlay/s6-rc.d/init-certbot-config/run` to create the symlink, rebuilt the container and tested in a known previously working deployment. The server started with multiple subdomains functioning as expected

I built the container on a Macbook (arm) but built for and deployed on `linux/amd64` as the Docker server running Sweag in my infrastructure runs Unraid. 


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->