### PR TITLE
Enable configurable DNS propagation time for Azure DNS plugin

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-certbot-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-certbot-config/run
@@ -300,7 +300,7 @@ if [[ "${VALIDATION}" = "dns" ]]; then
         sed -i "/^dns-${DNSPLUGIN}-credentials\b/d" /config/etc/letsencrypt/cli.ini
     fi
     # plugins that don't support setting propagation
-    if [[ "${DNSPLUGIN}" =~ ^(azure|gandi|route53|standalone)$ ]]; then
+    if [[ "${DNSPLUGIN}" =~ ^(gandi|route53|standalone)$ ]]; then
         if [[ -n "${PROPAGATION}" ]]; then echo "${DNSPLUGIN} dns plugin does not support setting propagation time"; fi
         sed -i "/^dns-${DNSPLUGIN}-propagation-seconds\b/d" /config/etc/letsencrypt/cli.ini
     fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-swag/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Add support for the PROPAGATION environment variable to the Azure DNS plugin, allowing configurable wait times for DNS record propagation.

## Benefits of this PR and context:
Prior to this change, the Azure DNS plugin ignored propagation delays and could fail DNS-01 challenges when records hadn’t yet propagated. By honoring the PROPAGATION setting, the plugin now behaves consistently with Certbot’s propagation mechanism and aligns with other DNS providers.

## How Has This Been Tested?
After confirming that the Azure DNS plugin supports configurable propagation time with Certbot, I removed it from the list of DNS plugins that lack propagation-time support. Then I cleared the letsencrypt folder, requested a new certificate, and reviewed the logs to verify that the propagation delay was applied correctly.


## Source / References:

