### PR TITLE
Disable Certbot's built in log rotation

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -205,6 +205,7 @@ init_diagram: |
   "swag:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "05.05.25:", desc: "Disable Certbot's built in log rotation."}
   - {date: "19.01.25:", desc: "Add [Auto Reload](https://github.com/linuxserver/docker-mods/tree/swag-auto-reload) functionality to SWAG."}
   - {date: "17.12.24:", desc: "Rebase to Alpine 3.21."}
   - {date: "21.10.24:", desc: "Fix naming issue with Dynu plugin. If you are using Dynu, please make sure your credentials are set in /config/dns-conf/dynu.ini and your DNSPLUGIN variable is set to dynu (not dynudns)."}

--- a/root/etc/s6-overlay/s6-rc.d/init-certbot-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-certbot-config/run
@@ -59,6 +59,9 @@ grep -qF 'agree-tos' /config/etc/letsencrypt/cli.ini || echo 'agree-tos=true' >>
 # Check for broken dns credentials value in cli.ini and remove
 sed -i '/dns--credentials/d' /config/etc/letsencrypt/cli.ini
 
+# Disable Certbot's built in log rotation
+set_ini_value "max-log-backups" "0" /config/etc/letsencrypt/cli.ini
+
 # copy dns default configs
 cp -n /defaults/dns-conf/* /config/dns-conf/ 2> >(grep -v 'cp: not replacing')
 lsiown -R abc:abc /config/dns-conf


### PR DESCRIPTION
Refs:
https://eff-certbot.readthedocs.io/en/stable/using.html#log-rotation
https://eff-certbot.readthedocs.io/en/stable/using.html#certbot-command-line-options
https://github.com/certbot/certbot/blob/62361dac442c065005455a0c78ea066fedc6c5f8/certbot/src/certbot/_internal/log.py#L172

Certbot's new log rotate functionality performs a rotation on every run of the `certbot` command. Our init runs the command at least one time (up to 4 times depending on conditional logic), and then `cron` runs daily. I investigated using their built-in log rotate, but it is less ideal to keep logs over time if a container is frequently restarted or updated because this reduces the time period for logs that would be kept by certbot's built in log rotation.