### PR TITLE
Gandi.net API key is deprecated in favor of Gandi.net Personal Access Token (PAT)

### DIFF
--- a/root/defaults/dns-conf/gandi.ini
+++ b/root/defaults/dns-conf/gandi.ini
@@ -1,7 +1,7 @@
 # Instructions: https://github.com/obynio/certbot-plugin-gandi#usage
 # Replace with your value
 # live dns v5 api key
-dns_gandi_api_key=APIKEY
+dns_gandi_token=TOKEN
 
 # optional organization id, remove it if not used
 #dns_gandi_sharing_id=SHARINGID


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-swag/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->

(Re)enable the support of the Gandi API Personal Access Token (PAT) for the Gandi DNS plugin located at `root/defaults/dns-conf/gandi.ini` with the correct name of the variable used in [Gandi Certbot plugin](https://github.com/obynio/certbot-plugin-gandi) on which this project depends.

Actually in `root/defaults/dns-conf/gandi.ini`:
```
dns_gandi_api_key=APIKEY
```

but that has to be changed to:
```
dns_gandi_token=PERSONAL_ACCESS_TOKEN
```
Since linuxserver/docker-swag no longer work with the old `dns_gandi_api_key` variable in gandi.ini file, as it refers to the Gandi API Key authentication method, which is obsolete. `dns_gandi_token` is the correct variable used with Gandi PAT in the Gandi Certbot Plugin.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Before this change, the Gandi Certbot plugin accepted both the Gandi API key and the Gandi personal access token. Now, only the personal access token is supported by the Gandi Certbot plugin.

Linked issues : [#426](https://github.com/linuxserver/docker-swag/issues/426)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
After having issues when I would like to setup a new instance of docker-swag with a Gandi domain + DNS challenge. I tried to understand how the Gandi Certbot plugin works and I found in this in the documentation of Gandi Certbot Plugin repo :
<img width="861" height="182" alt="image" src="https://github.com/user-attachments/assets/4660d862-9b3d-493d-bd45-929282d75de4" />

I replaced the variable name by `dns_gandi_api_key=*******` in and I no longer have any problems. The certificate has been issued.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
- Gandi Certbot plugin > FAQ : https://github.com/obynio/certbot-plugin-gandi?tab=readme-ov-file#faq
  <img width="1267" height="123" alt="image" src="https://github.com/user-attachments/assets/ad3738d5-aba8-4e00-8bb3-106bc1481a78" />
- Gandi Authentication documentation : https://api.gandi.net/docs/authentication/
- 09.12.2023 - Personal Access Tokens (PAT): improved control over access to Gandi’s API : https://news.gandi.net/en/2023/09/pat-jetons-acces-personnels-api-gandi/