### PR TITLE
Add CERT_PROFILE support and improve ARI renewal scheduling

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -32,6 +32,7 @@ opt_param_usage_include_env: true
 opt_param_env_vars:
   - {env_var: "SUBDOMAINS", env_value: "www,", desc: "Subdomains you'd like the cert to cover (comma separated, no spaces) ie. `www,ftp,cloud`. For a wildcard cert, set this *exactly* to `wildcard` (wildcard cert is available via `dns` validation only)"}
   - {env_var: "CERTPROVIDER", env_value: "", desc: "Optionally define the cert provider. Set to `zerossl` for ZeroSSL certs (requires existing [ZeroSSL account](https://app.zerossl.com/signup) and the e-mail address entered in `EMAIL` env var). Otherwise defaults to Let's Encrypt."}
+  - {env_var: "CERT_PROFILE", env_value: "", desc: "Optionally define a cert profile to use for cert generation. This is useful if you want to use a custom cert profile instead of the default one. Currently only supported for Let's Encrypt. See https://letsencrypt.org/docs/profiles/ "}
   - {env_var: "DNSPLUGIN", env_value: "cloudflare", desc: "Required if `VALIDATION` is set to `dns`. Options are `acmedns`, `aliyun`, `azure`, `bunny`, `cloudflare`, `cpanel`, `desec`, `digitalocean`, `directadmin`, `dnsimple`, `dnsmadeeasy`, `dnspod`, `do`, `domeneshop`, `dreamhost`, `duckdns`, `dynu`, `freedns`, `gandi`, `gehirn`, `glesys`, `godaddy`, `google`, `he`, `hetzner`, `hetzner-cloud`, `infomaniak`, `inwx`, `ionos`, `linode`, `loopia`, `luadns`, `mijn-host`, `namecheap`, `netcup`, `njalla`, `nsone`, `ovh`, `porkbun`, `rfc2136`, `route53`, `sakuracloud`, `standalone`, `transip`, and `vultr`. Also need to enter the credentials into the corresponding ini (or json for some plugins) file under `/config/dns-conf`."}
   - {env_var: "PROPAGATION", env_value: "", desc: "Optionally override (in seconds) the default propagation time for the dns plugins."}
   - {env_var: "EMAIL", env_value: "", desc: "Optional e-mail address used for cert expiration notifications (Required for ZeroSSL)."}
@@ -65,7 +66,7 @@ app_setup_block: |
       2. Certs that cover sub-subdomains of your main subdomain (ie. `*.yoursubdomain.duckdns.org`, set the `SUBDOMAINS` variable to `wildcard`)
   * `--cap-add=NET_ADMIN` is required for fail2ban to modify iptables
   * After setup, navigate to `https://example.com` to access the default homepage (http access through port 80 is disabled by default, you can enable it by editing the default site config at `/config/nginx/site-confs/default.conf`).
-  * Certs are checked nightly and if expiration is within 30 days, renewal is attempted. If your cert is about to expire in less than 30 days, check the logs under `/config/log/letsencrypt` to see why the renewals have been failing. It is recommended to input your e-mail in docker parameters so you receive expiration notices from Let's Encrypt in those circumstances.
+  * Certs are checked twice daily using ACME Renewal Information (ARI) to determine the optimal renewal window. If your cert is about to expire, check the logs under `/config/log/letsencrypt` to see why the renewals have been failing.
 
   ### Certbot Plugins
 
@@ -219,6 +220,7 @@ init_diagram: |
   "swag:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "10.07.26:", desc: "Add support for Let's Encrypt cert profiles. Run certbot twice daily with a random delay." }
   - {date: "19.06.26:", desc: "Add support for mijn.host dns validation."}
   - {date: "01.06.26:", desc: "Remove obsolete old cert check logic."}
   - {date: "23.01.26:", desc: "Reorder init to fix proxy conf version checks."}

--- a/root/etc/crontabs/root
+++ b/root/etc/crontabs/root
@@ -5,4 +5,4 @@
 0       3       *       *       6       run-parts /etc/periodic/weekly
 0       5       1       *       *       run-parts /etc/periodic/monthly
 
-8       2       *       *       *       /app/le-renew.sh >> /config/log/letsencrypt/renewal.log 2>&1
+0       */12    *       *       *       sleep $((60 + $RANDOM % 230)); /app/le-renew.sh >> /config/log/letsencrypt/renewal.log 2>&1

--- a/root/etc/s6-overlay/s6-rc.d/init-certbot-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-certbot-config/run
@@ -12,12 +12,13 @@ EXTRA_DOMAINS=${EXTRA_DOMAINS}\\n\
 ONLY_SUBDOMAINS=${ONLY_SUBDOMAINS}\\n\
 VALIDATION=${VALIDATION}\\n\
 CERTPROVIDER=${CERTPROVIDER}\\n\
+CERT_PROFILE=${CERT_PROFILE}\\n\
 DNSPLUGIN=${DNSPLUGIN}\\n\
 EMAIL=${EMAIL}\\n\
 STAGING=${STAGING}\\n"
 
 # Sanitize variables
-SANED_VARS=(DNSPLUGIN EMAIL EXTRA_DOMAINS ONLY_SUBDOMAINS STAGING SUBDOMAINS URL VALIDATION CERTPROVIDER)
+SANED_VARS=(DNSPLUGIN EMAIL EXTRA_DOMAINS ONLY_SUBDOMAINS STAGING SUBDOMAINS URL VALIDATION CERTPROVIDER CERT_PROFILE)
 for i in "${SANED_VARS[@]}"; do
     export echo "${i}"="${!i//\"/}"
     export echo "${i}"="$(echo "${!i}" | tr '[:upper:]' '[:lower:]')"
@@ -80,7 +81,7 @@ if [[ -f "/config/donoteditthisfile.conf" ]]; then
     mv /config/donoteditthisfile.conf /config/.donoteditthisfile.conf
 fi
 if [[ ! -f "/config/.donoteditthisfile.conf" ]]; then
-    echo -e "ORIGURL=\"${URL}\" ORIGSUBDOMAINS=\"${SUBDOMAINS}\" ORIGONLY_SUBDOMAINS=\"${ONLY_SUBDOMAINS}\" ORIGEXTRA_DOMAINS=\"${EXTRA_DOMAINS}\" ORIGVALIDATION=\"${VALIDATION}\" ORIGDNSPLUGIN=\"${DNSPLUGIN}\" ORIGPROPAGATION=\"${PROPAGATION}\" ORIGSTAGING=\"${STAGING}\" ORIGCERTPROVIDER=\"${CERTPROVIDER}\" ORIGEMAIL=\"${EMAIL}\"" >/config/.donoteditthisfile.conf
+    echo -e "ORIGURL=\"${URL}\" ORIGSUBDOMAINS=\"${SUBDOMAINS}\" ORIGONLY_SUBDOMAINS=\"${ONLY_SUBDOMAINS}\" ORIGEXTRA_DOMAINS=\"${EXTRA_DOMAINS}\" ORIGVALIDATION=\"${VALIDATION}\" ORIGDNSPLUGIN=\"${DNSPLUGIN}\" ORIGPROPAGATION=\"${PROPAGATION}\" ORIGSTAGING=\"${STAGING}\" ORIGCERTPROVIDER=\"${CERTPROVIDER}\" ORIGEMAIL=\"${EMAIL}\" ORIGCERT_PROFILE=\"${CERT_PROFILE}\"" >/config/.donoteditthisfile.conf
     echo "Created .donoteditthisfile.conf"
 fi
 
@@ -186,7 +187,8 @@ if [[ ! "${URL}" = "${ORIGURL}" ]] ||
     [[ ! "${DNSPLUGIN}" = "${ORIGDNSPLUGIN}" ]] ||
     [[ ! "${PROPAGATION}" = "${ORIGPROPAGATION}" ]] ||
     [[ ! "${STAGING}" = "${ORIGSTAGING}" ]] ||
-    [[ ! "${CERTPROVIDER}" = "${ORIGCERTPROVIDER}" ]]; then
+    [[ ! "${CERTPROVIDER}" = "${ORIGCERTPROVIDER}" ]] ||
+    [[ ! "${CERT_PROFILE}" = "${ORIGCERT_PROFILE}" ]]; then
     echo "Different validation parameters entered than what was used before. Revoking and deleting existing certificate, and an updated one will be created"
     if [[ "${ORIGCERTPROVIDER}" = "zerossl" ]]; then
         REV_ACMESERVER=("https://acme.zerossl.com/v2/DV90")
@@ -204,7 +206,7 @@ if [[ ! "${URL}" = "${ORIGURL}" ]] ||
 fi
 
 # saving new variables
-echo -e "ORIGURL=\"${URL}\" ORIGSUBDOMAINS=\"${SUBDOMAINS}\" ORIGONLY_SUBDOMAINS=\"${ONLY_SUBDOMAINS}\" ORIGEXTRA_DOMAINS=\"${EXTRA_DOMAINS}\" ORIGVALIDATION=\"${VALIDATION}\" ORIGDNSPLUGIN=\"${DNSPLUGIN}\" ORIGPROPAGATION=\"${PROPAGATION}\" ORIGSTAGING=\"${STAGING}\" ORIGCERTPROVIDER=\"${CERTPROVIDER}\" ORIGEMAIL=\"${EMAIL}\"" >/config/.donoteditthisfile.conf
+echo -e "ORIGURL=\"${URL}\" ORIGSUBDOMAINS=\"${SUBDOMAINS}\" ORIGONLY_SUBDOMAINS=\"${ONLY_SUBDOMAINS}\" ORIGEXTRA_DOMAINS=\"${EXTRA_DOMAINS}\" ORIGVALIDATION=\"${VALIDATION}\" ORIGDNSPLUGIN=\"${DNSPLUGIN}\" ORIGPROPAGATION=\"${PROPAGATION}\" ORIGSTAGING=\"${STAGING}\" ORIGCERTPROVIDER=\"${CERTPROVIDER}\" ORIGEMAIL=\"${EMAIL}\" ORIGCERT_PROFILE=\"${CERT_PROFILE}\"" >/config/.donoteditthisfile.conf
 
 # if zerossl is selected or staging is set to true, use the relevant server
 if [[ "${CERTPROVIDER}" = "zerossl" ]] && [[ "${STAGING}" = "true" ]]; then
@@ -226,6 +228,21 @@ else
 fi
 
 set_ini_value "server" "${ACMESERVER}" /config/etc/letsencrypt/cli.ini
+
+# set certificate profile (e.g. "shortlived" for 6-day certs, "classic" for 90-day)
+# Profiles are a Let's Encrypt ACME feature; ZeroSSL ignores it.
+if [[ -n "${CERT_PROFILE}" ]]; then
+    if [[ "${CERTPROVIDER}" = "zerossl" ]]; then
+        echo "ZeroSSL does not support ACME profiles, ignoring CERT_PROFILE variable"
+        sed -i "/^preferred-profile\b/d" /config/etc/letsencrypt/cli.ini
+    else
+        echo "Requesting certificate with profile: ${CERT_PROFILE}"
+        set_ini_value "preferred-profile" "${CERT_PROFILE}" /config/etc/letsencrypt/cli.ini
+    fi
+else
+    # remove if previously set so going back to default works
+    sed -i "/^preferred-profile\b/d" /config/etc/letsencrypt/cli.ini
+fi
 
 # figuring out domain only vs domain & subdomains vs subdomains only
 DOMAINS_ARRAY=()

--- a/root/etc/s6-overlay/s6-rc.d/init-renew/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-renew/run
@@ -3,7 +3,7 @@
 
 # Check if the cert is expired or expires within a day, if so, renew
 if openssl x509 -in /config/keys/letsencrypt/fullchain.pem -noout -checkend 86400 >/dev/null; then
-    echo "The cert does not expire within the next day. Letting the cron script handle the renewal attempts overnight (2:08am)."
+    echo "The cert does not expire within the next day. Letting the cron script handle the renewal attempts."
 else
     echo "The cert is either expired or it expires within the next day. Attempting to renew. This could take up to 10 minutes."
     /app/le-renew.sh


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
<!--- Before submitting a pull request please check the following -->
<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->
<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->
------------------------------
 - [x] I have read the [contributing](https://github.com/linuxserver/docker-swag/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications
------------------------------
<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->
<h2>Description:</h2>
<strong>1. CERT_PROFILE environment variable</strong>
<p>Adds support for the <code>CERT_PROFILE</code> environment variable, allowing users to request a specific Let's Encrypt certificate profile via certbot's <code>preferred-profile</code> flag. Supported profiles:</p>
<table>
  <tr><th>Profile</th><th>Validity</th><th>Notes</th></tr>
  <tr><td><code>classic</code></td><td>90 days</td><td>Default, backward compatible</td></tr>
  <tr><td><code>tlsserver</code></td><td>Short window</td><td>Modern CA/B Forum standard, omits Common Name, max 25 domains</td></tr>
  <tr><td><code>shortlived</code></td><td>6 days (~160 hours)</td><td>No revocation info, smaller certs, fully automated systems only</td></tr>
  <tr><td><code>tlsclient</code></td><td>90 days</td><td>TLS client auth EKU — being discontinued July 8, 2026</td></tr>
</table>
<p>ZeroSSL does not support ACME profiles and the variable is silently ignored when <code>CERTPROVIDER=zerossl</code>.</p>
<strong>2. ARI-aware renewal scheduling</strong>
<p>Changes certbot renew from once daily to twice daily (<code>*/12</code>) per the <a href="https://letsencrypt.org/docs/integration-guide/">Let's Encrypt Integration Guide</a> recommendation to check ARI at least twice daily. </p>
<p>Additionally randomizes the cron minute offset (0–59) on each container start to spread renewal load across instances, and logs the next scheduled check time at startup.</p>
<p>Updates the readme to reflect twice daily cert checks via ARI and removes the outdated reference to Let's Encrypt expiration notification emails which <a href="https://letsencrypt.org/2025/06/26/expiration-notification-service-has-ended">ended in June 2025</a>.</p>
<h2>Benefits of this PR and context:</h2>
<p><strong>CERT_PROFILE</strong> enables users to adopt shorter-lived certificates today. This is directly relevant to the whole SWAG userbase given Let's Encrypt's announced roadmap:</p>
<ul>
  <li><strong>Feb 10, 2027:</strong> Default classic profile moves from 90-day to 64-day</li>
  <li><strong>Feb 16, 2028:</strong> Default profile moves to 45-day</li>
</ul>
<p>Lays the groundwork for support for ip certificates which requires 6 day certs.<a href="https://letsencrypt.org/2026/03/11/shorter-certs-certbot">Six-Day and IP Address Certificates Available in Certbot</a></p>
<p>As certificate lifetimes shorten, ARI renewal windows become proportionally narrower. The twice daily cron change is forward-looking — what currently only matters for shortlived users will affect all SWAG users as default lifetimes decrease.</p>
<h2>How Has This Been Tested?</h2>
<p>Built the Docker image locally on an Unraid server and tested:</p>
<ul>
  <li>Set <code>CERT_PROFILE=shortlived</code> in staging and production mode — received a 6-day certificate both times:</li>
</ul>
<img width="409" height="275" alt="image" src="https://github.com/user-attachments/assets/ab6abd6a-9b87-4e8c-9215-a047d45fa5e1" />
<ul>
  <li>Confirmed ARI is being queried at each renewal check via <code>grep renewalInfo /config/log/letsencrypt/letsencrypt.log</code></li>
  <li>Confirmed randomized cron offset appears in Docker logs at startup</li>
  <li>Confirmed next scheduled check time displayed correctly at startup</li>
  <li>Verified full ARI <code>suggestedWindow</code> response showing a ~3 hour window set at the cert's halfway point (day 3 of 6)</li>
</ul>
<h2>Source / References:</h2>
<ul>
  <li><a href="https://letsencrypt.org/docs/profiles/">https://letsencrypt.org/docs/profiles/</a> — certificate profiles documentation</li>
  <li><a href="https://letsencrypt.org/docs/integration-guide/">https://letsencrypt.org/docs/integration-guide/</a> — "check ARI at least twice a day"</li>
  <li><a href="https://letsencrypt.org/2026/03/17/acme-renewal-information-ari">https://letsencrypt.org/2026/03/17/acme-renewal-information-ari</a> — ARI overview</li>
  <li><a href="https://letsencrypt.org/2025/06/26/expiration-notification-service-has-ended">https://letsencrypt.org/2025/06/26/expiration-notification-service-has-ended</a> — expiration emails ended</li>
  <li><a href="https://letsencrypt.org/2026/03/11/shorter-certs-certbot">https://letsencrypt.org/2026/03/11/shorter-certs-certbot</a> — shorter-certs-certbot</li>
</ul>